### PR TITLE
Change context path to oar-dist-service

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -9,7 +9,7 @@ spring:
        
 server:
     port: 8083
-    contextPath: /od/ds
+    contextPath: /oar-dist-service
     error:
       include-stacktrace: never
     connection-timeout: 60000


### PR DESCRIPTION
Change context path to od/ds is not working, reverting changes to
oar-dist-service