### PR TITLE
ODD-541: Avoid use of cache, fix download-all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Brixton.SR6</version>
+				<version>Camden.SR7</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -53,10 +53,16 @@
 		</dependency>
 		<!-- <dependency> <groupId>org.springframework.boot</groupId> <artifactId>spring-boot-starter-freemarker</artifactId> 
 			<version>${spring.boot.version}</version> </dependency> -->
-		<dependency>
+		 <dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-aws-context</artifactId>
-		</dependency>
+		</dependency> 
+		<!-- <dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-aws-context</artifactId>
+    <version>2.0.0.M1</version>
+</dependency> -->
+
 		<dependency>
 		    <groupId>com.googlecode.json-simple</groupId>
 		    <artifactId>json-simple</artifactId>
@@ -64,7 +70,8 @@
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
+    		<artifactId>commons-io</artifactId>
+    		<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -105,6 +112,8 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>
+		
+	
 	</dependencies>
 	<build>
 		<finalName>oar-dist-service</finalName>
@@ -236,6 +245,5 @@
 			</snapshots>
 		</repository>
 	</repositories>
-
 
 </project>

--- a/src/main/java/gov/nist/oar/ds/config/ApplicationConfig.java
+++ b/src/main/java/gov/nist/oar/ds/config/ApplicationConfig.java
@@ -36,7 +36,7 @@ public class ApplicationConfig {
    * Main runner of the spring-boot class
    * 
    * @param args
-   */
+   */	
   @SuppressWarnings("squid:S2095")
   public static void main(String... args) {
     log.info("########## Starting oar distribution service ########");

--- a/src/main/java/gov/nist/oar/ds/config/S3Config.java
+++ b/src/main/java/gov/nist/oar/ds/config/S3Config.java
@@ -17,24 +17,47 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-
+import com.amazonaws.client.builder.AwsClientBuilder;
 /**
  * This is the config class responsible of starting the s3 client in dev and prod environment
  *
  */
 @Configuration
+
 public class S3Config {
 
   private static Logger log = LoggerFactory.getLogger(S3Config.class);
 
   @Bean
+  @Profile({"prod", "dev", "test"})
   public AmazonS3Client s3Client() {
     log.info("Creating s3 client instance");
     InstanceProfileCredentialsProvider provider = new InstanceProfileCredentialsProvider();
     return (AmazonS3Client) AmazonS3ClientBuilder.standard().withCredentials(provider).build();
   }
+  
+  @Bean
+  @Profile("default")
+  public AmazonS3 s3Clientlocal() {
+	    log.info("Creating s3 client instance");
+	   
+	    return AmazonS3ClientBuilder
+	              .standard()
+	              .withPathStyleAccessEnabled(true)
+	              .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("http://localhost:8001", "us-east-1"))
+	              .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+	              .build();
+	    
+	    } 
+  
 }

--- a/src/main/java/gov/nist/oar/ds/config/S3ConfigLocal.java
+++ b/src/main/java/gov/nist/oar/ds/config/S3ConfigLocal.java
@@ -1,0 +1,60 @@
+///**
+// * This software was developed at the National Institute of Standards and Technology by employees of
+// * the Federal Government in the course of their official duties. Pursuant to title 17 Section 105
+// * of the United States Code this software is not subject to copyright protection and is in the
+// * public domain. This is an experimental system. NIST assumes no responsibility whatsoever for its
+// * use by other parties, and makes no guarantees, expressed or implied, about its quality,
+// * reliability, or any other characteristic. We would appreciate acknowledgement if the software is
+// * used. This software can be redistributed and/or modified freely provided that any derivative
+// * works bear some notice that they are derived from it, and any modified versions bear some notice
+// * that they have been modified.
+// * 
+// * @author:Harold Affo (Prometheus Computing, LLC)
+// */
+//package gov.nist.oar.ds.config;
+//
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.context.annotation.Profile;
+//
+//import com.amazonaws.ClientConfiguration;
+//import com.amazonaws.auth.AWSStaticCredentialsProvider;
+//import com.amazonaws.auth.AnonymousAWSCredentials;
+//import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+//import com.amazonaws.regions.Regions;
+//import com.amazonaws.services.s3.AmazonS3;
+//import com.amazonaws.services.s3.AmazonS3Client;
+//import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+//import com.amazonaws.client.builder.AwsClientBuilder;
+///**
+// * This is the config class responsible of starting the s3 client in dev and prod environment
+// *
+// */
+//@Configuration
+//@Profile("local")
+//public class S3ConfigLocal {
+//
+//  private static Logger log = LoggerFactory.getLogger(S3ConfigLocal.class);
+//
+////  @Bean
+////  public AmazonS3Client s3Client() {
+////    log.info("Creating s3 client instance");
+////    InstanceProfileCredentialsProvider provider = new InstanceProfileCredentialsProvider();
+////    return (AmazonS3Client) AmazonS3ClientBuilder.standard().withCredentials(provider).build();
+////  }
+//  @Bean
+//  public AmazonS3 s3Client() {
+//	    log.info("Creating s3 client instance");
+//	   
+//	    return AmazonS3ClientBuilder
+//	              .standard()
+//	              .withPathStyleAccessEnabled(true)
+//	              .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("http://localhost:8001", "us-east-1"))
+//	              .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+//	              .build();
+//	    
+//	    } 
+//  
+//}

--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -15,6 +15,9 @@ package gov.nist.oar.ds.controller;
 
 import java.io.IOException;
 import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.http.HttpStatus;
 import gov.nist.oar.ds.service.DownloadService;
 import io.swagger.annotations.Api;
@@ -53,98 +57,139 @@ public class DownloadController {
   }
   
 
-  /**
-   * 
-   * @return
-   */
-  @ApiOperation(value = "Returns distriubution rest api info.",nickname = "get content",
-  notes = "Index Controller.")
-  public ResponseEntity<String> index() {
-    logger.info("Loading index page");
-    return new ResponseEntity<>(CONTENT, HttpStatus.OK);
-  }
+//  /**
+//   * 
+//   * @return
+//   */
+//  @ApiOperation(value = "Returns distriubution rest api info.",nickname = "get content",
+//  notes = "Index Controller.")
+//  public ResponseEntity<String> index() {
+//    logger.info("Loading index page");
+//    return new ResponseEntity<>(CONTENT, HttpStatus.OK);
+//  }
+//  
+//
+//  /**
+//   * Download a distribution file by its id
+//   * 
+//   * @param dsId
+//   * @param distId
+//   * @return
+//   * @throws IOException
+//   */
+//  @RequestMapping(value = "/{dsId}/{distId}", method = RequestMethod.GET)
+//  @ApiOperation(value = "Get data for given distribution with distribution id.",nickname = "distById",
+//  notes = "distID is data collection id and distId is actual data id.")
+//
+//  public ResponseEntity<byte[]> download(@PathVariable("dsId") String dsId,
+//      @PathVariable("distId") String distId) throws IOException {
+//    logger.info("Downloading distribution file with distId=" + distId + " dsId=" + dsId);
+//    return downloadService.downloadDistributionFile(dsId, distId);
+//  }
+//
+//
+//  /**
+//   * Return the list of bags of a data set
+//   * 
+//   * @param dsId
+//   * @return
+//   * @throws IOException
+//   */
+//  @RequestMapping(value = "/{dsId}/bags", method = RequestMethod.GET)
+//  @ApiOperation(value = "Get bags for given distribution",nickname = "get bags",
+//  notes = "Find Data Set bags for given disId")
+//  public ResponseEntity<List<String>> listDataSetBags(@PathVariable("dsId") String dsId)
+//      throws IOException {
+//    return downloadService.findDataSetBags(dsId);
+//  }
+//
+//  /**
+//   * Return the head bag key of a data set
+//   * 
+//   * @param dsId: id of the data set
+//   * @return the head bag key of a data set
+//   * @throws IOException
+//   */
+//  @RequestMapping(value = "/{dsId}/headBag", method = RequestMethod.GET)
+//  @ApiOperation(value = "Get HeadBag for given distribution Id.",nickname = "get headbag",
+//  notes = "Get Headbag for given distribution with distID")
+//
+//  public ResponseEntity<String> headBag(@PathVariable("dsId") String dsId) throws IOException {
+//    return downloadService.findDataSetHeadBag(dsId);
+//  }
+//
+//
+//  /**
+//   * Cache a data set
+//   * 
+//   * @param dsId
+//   * @return
+//   * @throws IOException
+//   */
+//  @RequestMapping(value = "/{dsId}/cache", method = RequestMethod.POST)
+//  @ApiOperation(value = "Get Cache for given distribution",nickname = "get cache",
+//  notes = "Get data cache for given distribution by distribution ID.")
+//
+//  public ResponseEntity<byte[]> cacheDataSet(@PathVariable("dsId") String dsId) throws IOException {
+//    return null;
+//  }
+//
+//  /**
+//   * Download zip file
+//   * 
+//   * @param Id
+//   * @return 
+//   * @return
+//   * @throws Exception 
+//   */
+//  @RequestMapping(value = "/zip", method = RequestMethod.GET)
+//
+//  public ResponseEntity<byte[]> downloadZipFile(String id) throws Exception {
+//    logger.info("Loading zip page" + id);
+//    return downloadService.downloadZipFile(id);
+//       
+//  }
   
+@RequestMapping(value = "/{dsId}", method = RequestMethod.GET)
 
-  /**
-   * Download a distribution file by its id
-   * 
-   * @param dsId
-   * @param distId
-   * @return
-   * @throws IOException
-   */
-  @RequestMapping(value = "/{dsId}/{distId}", method = RequestMethod.GET)
-  @ApiOperation(value = "Get data for given distribution with distribution id.",nickname = "distById",
-  notes = "distID is data collection id and distId is actual data id.")
+public ResponseEntity<byte[]> downloadAlldata(@PathVariable("dsId") String dsid) throws Exception {
+  logger.info("Loading zip page" + dsid);
+  return downloadService.downloadAllData(dsid);
+     
+}
 
-  public ResponseEntity<byte[]> download(@PathVariable("dsId") String dsId,
-      @PathVariable("distId") String distId) throws IOException {
-    logger.info("Downloading distribution file with distId=" + distId + " dsId=" + dsId);
-    return downloadService.downloadDistributionFile(dsId, distId);
+//@RequestMapping(value = "/{dsId}/{filepath:.+}", method = RequestMethod.GET)
+//
+//public ResponseEntity<byte[]> downloadAlldata(@PathVariable("dsId") String dsid, @PathVariable("filepath") String filepath) throws Exception {
+//  logger.info("Loading zip page" + dsid);
+//  return downloadService.downloadData(dsid,filepath);
+//     
+//}
+
+@RequestMapping(value = "/{dsId}/**", method = RequestMethod.GET)
+
+public ResponseEntity<byte[]> downloadData(@PathVariable("dsId") String dsid, HttpServletRequest request) throws Exception {
+  logger.info("Loading zip page" + dsid);
+  try{
+	  String restOfTheUrl = (String) request.getAttribute(
+	        HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+	  restOfTheUrl = restOfTheUrl.replace("/"+dsid+"/", "");
+	    logger.info(restOfTheUrl);
+	  return downloadService.downloadData(dsid,restOfTheUrl);
+  }catch(Exception e){
+	  throw e;
   }
+	
+     
+}
 
-
-  /**
-   * Return the list of bags of a data set
-   * 
-   * @param dsId
-   * @return
-   * @throws IOException
-   */
-  @RequestMapping(value = "/{dsId}/bags", method = RequestMethod.GET)
-  @ApiOperation(value = "Get bags for given distribution",nickname = "get bags",
-  notes = "Find Data Set bags for given disId")
-  public ResponseEntity<List<String>> listDataSetBags(@PathVariable("dsId") String dsId)
-      throws IOException {
-    return downloadService.findDataSetBags(dsId);
-  }
-
-  /**
-   * Return the head bag key of a data set
-   * 
-   * @param dsId: id of the data set
-   * @return the head bag key of a data set
-   * @throws IOException
-   */
-  @RequestMapping(value = "/{dsId}/headBag", method = RequestMethod.GET)
-  @ApiOperation(value = "Get HeadBag for given distribution Id.",nickname = "get headbag",
-  notes = "Get Headbag for given distribution with distID")
-
-  public ResponseEntity<String> headBag(@PathVariable("dsId") String dsId) throws IOException {
-    return downloadService.findDataSetHeadBag(dsId);
-  }
-
-
-  /**
-   * Cache a data set
-   * 
-   * @param dsId
-   * @return
-   * @throws IOException
-   */
-  @RequestMapping(value = "/{dsId}/cache", method = RequestMethod.POST)
-  @ApiOperation(value = "Get Cache for given distribution",nickname = "get cache",
-  notes = "Get data cache for given distribution by distribution ID.")
-
-  public ResponseEntity<byte[]> cacheDataSet(@PathVariable("dsId") String dsId) throws IOException {
-    return null;
-  }
-
-  /**
-   * Download zip file
-   * 
-   * @param Id
-   * @return 
-   * @return
-   * @throws Exception 
-   */
-  @RequestMapping(value = "/zip", method = RequestMethod.GET)
-
-  public ResponseEntity<byte[]> downloadZipFile(String id) throws Exception {
-    logger.info("Loading zip page" + id);
-    return downloadService.downloadZipFile(id);
-       
-  }
+//@RequestMapping(value="/{id}/**", method = RequestMethod.GET)
+//public void foo(@PathVariable("id") int id, HttpServletRequest request) {
+//    String restOfTheUrl = (String) request.getAttribute(
+//        HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+//    logger.info(restOfTheUrl);
+//   
+//}
 
 
 }

--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -145,7 +145,7 @@ public class DownloadController {
   @RequestMapping(value = "/{dsId}", method = RequestMethod.GET)
 
   public ResponseEntity<byte[]> downloadZipFile(String id) throws Exception {
-    logger.info("Loading zip page" + id);
+    logger.info("Handling zip download for dsid=" + id);
     return downloadService.downloadZipFile(id);
        
   }
@@ -169,12 +169,12 @@ public class DownloadController {
 @RequestMapping(value = "/{dsId}/**", method = RequestMethod.GET)
 
 public ResponseEntity<byte[]> downloadData(@PathVariable("dsId") String dsid, HttpServletRequest request) throws Exception {
-  logger.info("Loading zip page" + dsid);
+  logger.debug("Handling file request from dataset with id=" + dsid);
   try{
 	  String restOfTheUrl = (String) request.getAttribute(
 	        HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
 	  restOfTheUrl = restOfTheUrl.replace("/"+dsid+"/", "");
-	    logger.info(restOfTheUrl);
+            logger.info("Handling request for data file: id="+dsid+" path="+restOfTheUrl);
 	  return downloadService.downloadData(dsid,restOfTheUrl);
   }catch(Exception e){
 	  throw e;

--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -134,29 +134,29 @@ public class DownloadController {
 //    return null;
 //  }
 //
-//  /**
-//   * Download zip file
-//   * 
-//   * @param Id
-//   * @return 
-//   * @return
-//   * @throws Exception 
-//   */
-//  @RequestMapping(value = "/zip", method = RequestMethod.GET)
-//
-//  public ResponseEntity<byte[]> downloadZipFile(String id) throws Exception {
-//    logger.info("Loading zip page" + id);
-//    return downloadService.downloadZipFile(id);
-//       
-//  }
-  
-@RequestMapping(value = "/{dsId}", method = RequestMethod.GET)
+  /**
+   * Download zip file
+   * 
+   * @param Id
+   * @return 
+   * @return
+   * @throws Exception 
+   */
+  @RequestMapping(value = "/{dsId}", method = RequestMethod.GET)
 
-public ResponseEntity<byte[]> downloadAlldata(@PathVariable("dsId") String dsid) throws Exception {
-  logger.info("Loading zip page" + dsid);
-  return downloadService.downloadAllData(dsid);
-     
-}
+  public ResponseEntity<byte[]> downloadZipFile(String id) throws Exception {
+    logger.info("Loading zip page" + id);
+    return downloadService.downloadZipFile(id);
+       
+  }
+  
+//@RequestMapping(value = "/{dsId}", method = RequestMethod.GET)
+//
+//public ResponseEntity<byte[]> downloadAlldata(@PathVariable("dsId") String dsid) throws Exception {
+//  logger.info("Loading zip page" + dsid);
+//  return downloadService.downloadAllData(dsid);
+//     
+//}
 
 //@RequestMapping(value = "/{dsId}/{filepath:.+}", method = RequestMethod.GET)
 //

--- a/src/main/java/gov/nist/oar/ds/s3/S3Wrapper.java
+++ b/src/main/java/gov/nist/oar/ds/s3/S3Wrapper.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -43,6 +44,8 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 
 /**
  * This is the wrapper around the s3 client handling the connection to an s3 bucket
@@ -56,7 +59,7 @@ public class S3Wrapper {
 
 
   @Autowired
-  private AmazonS3Client s3Client;
+  private AmazonS3 s3Client;
 
 
   /**
@@ -129,6 +132,15 @@ public class S3Wrapper {
     httpHeaders.setContentDispositionFormData("attachment", fileName);
 
     return new ResponseEntity<>(bytes, httpHeaders, HttpStatus.OK);
+  }
+  
+  public void copytocache(String hostbucket, String hostkey, String destBucket, String destKey){
+	  CopyObjectRequest copyObjRequest = new CopyObjectRequest(hostbucket, hostkey, destBucket, destKey);
+	  s3Client.copyObject(copyObjRequest);
+  }
+  
+  public boolean doesObjectExistInCache(String cachebucket, String key){
+	  return s3Client.doesObjectExist(cachebucket,key);
   }
 
   /**

--- a/src/main/java/gov/nist/oar/ds/service/DownloadService.java
+++ b/src/main/java/gov/nist/oar/ds/service/DownloadService.java
@@ -31,48 +31,52 @@ import com.amazonaws.services.s3.model.PutObjectResult;
  */
 public interface DownloadService {
 
-  /**
-   * Upload distribution files to the cache s3
-   * 
-   * @param multipartFiles
-   * @return
-   */
-  public List<PutObjectResult> uploadToCache(MultipartFile[] multipartFiles);
+//  /**
+//   * Upload distribution files to the cache s3
+//   * 
+//   * @param multipartFiles
+//   * @return
+//   */
+//  public List<PutObjectResult> uploadToCache(MultipartFile[] multipartFiles);
+//
+//
+//  /**
+//   * Return a summary list of bags of a data set
+//   * 
+//   * @param dsId: id of the data set
+//   * @return the list of keys of the bags
+//   * @throws IOException
+//   */
+//  ResponseEntity<List<String>> findDataSetBags(String dsId) throws IOException;
+//
+//  /**
+//   * 
+//   * @param dsId
+//   * @param distId
+//   * @return
+//   * @throws IOException
+//   */
+//  ResponseEntity<byte[]> downloadDistributionFile(String dsId, String distId) throws IOException;
+//
+//  /**
+//   * Find the head bag of a data set by its id
+//   * 
+//   * @param dsId: id of the data set
+//   * @return the head bag key
+//   * @throws IOException
+//   */
+//  ResponseEntity<String> findDataSetHeadBag(String id) throws IOException;
 
-
-  /**
-   * Return a summary list of bags of a data set
-   * 
-   * @param dsId: id of the data set
-   * @return the list of keys of the bags
-   * @throws IOException
-   */
-  ResponseEntity<List<String>> findDataSetBags(String dsId) throws IOException;
-
-  /**
-   * 
-   * @param dsId
-   * @param distId
-   * @return
-   * @throws IOException
-   */
-  ResponseEntity<byte[]> downloadDistributionFile(String dsId, String distId) throws IOException;
-
-  /**
-   * Find the head bag of a data set by its id
-   * 
-   * @param dsId: id of the data set
-   * @return the head bag key
-   * @throws IOException
-   */
-  ResponseEntity<String> findDataSetHeadBag(String id) throws IOException;
-
-  /**
-   * 
-   * @param Id
-   * @return zip byte[] 
-   * @throws IOException
-   */
-  ResponseEntity<byte[]> downloadZipFile(String id) throws Exception; 
+//  /**
+//   * 
+//   * @param Id
+//   * @return zip byte[] 
+//   * @throws IOException
+//   */
+//  ResponseEntity<byte[]> downloadZipFile(String id) throws Exception; 
+	
+	ResponseEntity<byte[]> downloadAllData(String recordid) throws Exception;
+	
+	ResponseEntity<byte[]> downloadData(String recordid, String filepath) throws Exception;
   
 }

--- a/src/main/java/gov/nist/oar/ds/service/DownloadService.java
+++ b/src/main/java/gov/nist/oar/ds/service/DownloadService.java
@@ -67,15 +67,15 @@ public interface DownloadService {
 //   */
 //  ResponseEntity<String> findDataSetHeadBag(String id) throws IOException;
 
-//  /**
-//   * 
-//   * @param Id
-//   * @return zip byte[] 
-//   * @throws IOException
-//   */
-//  ResponseEntity<byte[]> downloadZipFile(String id) throws Exception; 
+  /**
+   * 
+   * @param Id
+   * @return zip byte[] 
+   * @throws IOException
+   */
+  ResponseEntity<byte[]> downloadZipFile(String id) throws Exception; 
 	
-	ResponseEntity<byte[]> downloadAllData(String recordid) throws Exception;
+//	ResponseEntity<byte[]> downloadAllData(String recordid) throws Exception;
 	
 	ResponseEntity<byte[]> downloadData(String recordid, String filepath) throws Exception;
   

--- a/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
+++ b/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
@@ -402,7 +402,8 @@ public class DownloadServiceImpl implements DownloadService {
 		  ByteArrayOutputStream out = new ByteArrayOutputStream();
 //		  if(!s3Wrapper.doesObjectExistInCache(cacheBucket, recordBagKey))
 //			  s3Wrapper.copytocache(preservationBucket, recordBagKey, cacheBucket,recordBagKey);
-		  
+
+                  logger.debug("Pulling data from bucket="+preservationBucket);
 		  ResponseEntity<byte[]> zipdata = s3Wrapper.download(preservationBucket,recordBagKey);
 		  ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipdata.getBody()));
 		  ZipEntry entry; 

--- a/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
+++ b/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
@@ -184,6 +184,7 @@ public class DownloadServiceImpl implements DownloadService {
    * @return
    * @throws Exception
    */
+  @Override
   public ResponseEntity<byte[]>  downloadZipFile(String id) throws Exception {
     
     try {    
@@ -355,7 +356,6 @@ public class DownloadServiceImpl implements DownloadService {
   }
   
   ////Deoyani Adding new methods:
-  @Override
   public ResponseEntity<byte[]> downloadAllData(String recordid) throws Exception{
 	  try{
 	   
@@ -400,10 +400,10 @@ public class DownloadServiceImpl implements DownloadService {
 		  
 		  String filename = recordBagKey.substring(0, recordBagKey.length()-4)+"/data/"+filepath;
 		  ByteArrayOutputStream out = new ByteArrayOutputStream();
-		  if(!s3Wrapper.doesObjectExistInCache(cacheBucket, recordBagKey))
-			  s3Wrapper.copytocache(preservationBucket, recordBagKey, cacheBucket,recordBagKey);
+//		  if(!s3Wrapper.doesObjectExistInCache(cacheBucket, recordBagKey))
+//			  s3Wrapper.copytocache(preservationBucket, recordBagKey, cacheBucket,recordBagKey);
 		  
-		  ResponseEntity<byte[]> zipdata = s3Wrapper.download(cacheBucket,recordBagKey);
+		  ResponseEntity<byte[]> zipdata = s3Wrapper.download(preservationBucket,recordBagKey);
 		  ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipdata.getBody()));
 		  ZipEntry entry; 
 		  while((entry = zis.getNextEntry()) != null)  {

--- a/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
+++ b/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
@@ -17,6 +17,7 @@ package gov.nist.oar.ds.service.impl;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
@@ -68,6 +69,9 @@ import com.google.gson.Gson;
 import gov.nist.oar.ds.s3.S3Wrapper;
 import gov.nist.oar.ds.service.DownloadService;
 
+import java.io.ByteArrayInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 /**
  * This is the default implementation of the download service class responsible of handling download
  * requests
@@ -94,22 +98,22 @@ public class DownloadServiceImpl implements DownloadService {
   private static final String MAPPING_FILE_PREFIX = "ore.json";
 
 
-  @Override
-  public List<PutObjectResult> uploadToCache(MultipartFile[] multipartFiles) {
-    return s3Wrapper.upload(cacheBucket, multipartFiles);
-  }
-
-
-  @Override
-  public ResponseEntity<byte[]> downloadDistributionFile(String dsId, String distId)
-      throws IOException {
-    logger.info("Downloading dsId=" + dsId + ",distId=" + distId + " from " + cacheBucket);
-    String fileKey = getDistributionFileKey(dsId, distId);
-    if (fileKey != null) {
-      return s3Wrapper.download(cacheBucket, fileKey);
-    }
-    return null;
-  }
+//  @Override
+//  public List<PutObjectResult> uploadToCache(MultipartFile[] multipartFiles) {
+//    return s3Wrapper.upload(cacheBucket, multipartFiles);
+//  }
+//
+//
+//  @Override
+//  public ResponseEntity<byte[]> downloadDistributionFile(String dsId, String distId)
+//      throws IOException {
+//    logger.info("Downloading dsId=" + dsId + ",distId=" + distId + " from " + cacheBucket);
+//    String fileKey = getDistributionFileKey(dsId, distId);
+//    if (fileKey != null) {
+//      return s3Wrapper.download(cacheBucket, fileKey);
+//    }
+//    return null;
+//  }
 
   /**
    * 
@@ -144,21 +148,21 @@ public class DownloadServiceImpl implements DownloadService {
     return results;
   }
 
+//
+//  @Override
+//  public ResponseEntity<List<String>> findDataSetBags(String dsId) throws IOException {
+//    return new ResponseEntity<>(findBagsById(dsId), HttpStatus.OK);
+//  }
 
-  @Override
-  public ResponseEntity<List<String>> findDataSetBags(String dsId) throws IOException {
-    return new ResponseEntity<>(findBagsById(dsId), HttpStatus.OK);
-  }
-
-
-  @Override
-  public ResponseEntity<String> findDataSetHeadBag(String dsId) throws IOException {
-    List<String> results = findBagsById(dsId);
-    if (results != null && !results.isEmpty()) {
-      return new ResponseEntity<>(results.get(0), HttpStatus.OK);
-    }
-    return new ResponseEntity<>(null, HttpStatus.OK);
-  }
+//
+//  @Override
+//  public ResponseEntity<String> findDataSetHeadBag(String dsId) throws IOException {
+//    List<String> results = findBagsById(dsId);
+//    if (results != null && !results.isEmpty()) {
+//      return new ResponseEntity<>(results.get(0), HttpStatus.OK);
+//    }
+//    return new ResponseEntity<>(null, HttpStatus.OK);
+//  }
 
   /**
    * 
@@ -307,4 +311,128 @@ public class DownloadServiceImpl implements DownloadService {
           .setSSLSocketFactory(connectionFactory)
           .build();
   }
+  	
+  
+  
+  public ResponseEntity<byte[]> getResponsEntity(String filename, byte[] outdata){
+		
+	  HttpHeaders httpHeaders = new HttpHeaders();
+	    httpHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+	    httpHeaders.setContentLength(outdata.length); 
+	    httpHeaders.setContentDispositionFormData("attachment", filename);
+	    return new ResponseEntity<>(outdata, httpHeaders, HttpStatus.OK);
+  }
+
+  public ResponseEntity<byte[]> downloadAllZiponlyData(String bucket, String key) throws Exception{
+	  
+	  try{
+		  byte[] outdata = new byte[ 9000];
+		  ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		  ZipOutputStream zos = new ZipOutputStream(bos);
+		  ResponseEntity<byte[]> zipdata = s3Wrapper.download(bucket,key);
+		  ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipdata.getBody()));
+		  ZipEntry entry; 
+		  while((entry = zis.getNextEntry()) != null)  {
+			  if (entry.getName().contains("/data/")) {
+				  zos.putNextEntry(entry);
+				  int len;
+				  while ((len = zis.read(outdata)) != -1) {
+					  zos.write(outdata, 0, len);
+				  }
+				  zos.closeEntry();
+			  }
+			    
+			}
+		  zis.close();
+		  zos.close();
+		  return getResponsEntity(key.substring(0, key.length()-14)+".zip", bos.toByteArray());
+		  
+		 
+	  }
+	  catch(Exception e){
+		  throw e;
+	  }
+  }
+  
+  ////Deoyani Adding new methods:
+  @Override
+  public ResponseEntity<byte[]> downloadAllData(String recordid) throws Exception{
+	  try{
+	   
+		  
+	   List<S3ObjectSummary> files = s3Wrapper.list(preservationBucket, recordid);
+	   
+	   
+	   if (files != null && !files.isEmpty()) {
+		  
+		  if(!s3Wrapper.doesObjectExistInCache(cacheBucket, files.get(files.size()-1).getKey()))
+			  s3Wrapper.copytocache(preservationBucket, files.get(files.size()-1).getKey(), cacheBucket,files.get(files.size()-1).getKey());
+		  //return s3Wrapper.download(cacheBucket, files.get(files.size()-1).getKey());
+		  return downloadAllZiponlyData(cacheBucket,files.get(files.size()-1).getKey());
+	   }
+	   else return null;
+	  
+
+	  }catch(Exception e){
+	    throw e;
+	  }
+	 
+  }
+  
+
+  
+  
+  @Override
+  public ResponseEntity<byte[]> downloadData(String recordid, String filepath) throws Exception{
+	  try{
+	   
+	  
+	   List<S3ObjectSummary> files = s3Wrapper.list(preservationBucket, recordid);
+	   
+//	    
+//	  if (files != null && !files.isEmpty())
+//		  return null ;
+	  
+	  
+	     String recordBagKey = files.get(files.size()-1).getKey();
+		  
+	     byte[] outdata = new byte[ 9000];
+		  
+		  String filename = recordBagKey.substring(0, recordBagKey.length()-4)+"/data/"+filepath;
+		  ByteArrayOutputStream out = new ByteArrayOutputStream();
+		  if(!s3Wrapper.doesObjectExistInCache(cacheBucket, recordBagKey))
+			  s3Wrapper.copytocache(preservationBucket, recordBagKey, cacheBucket,recordBagKey);
+		  
+		  ResponseEntity<byte[]> zipdata = s3Wrapper.download(cacheBucket,recordBagKey);
+		  ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipdata.getBody()));
+		  ZipEntry entry; 
+		  while((entry = zis.getNextEntry()) != null)  {
+			  if (entry.getName().equals(filename)) {
+				  int len;
+				  while ((len = zis.read(outdata)) != -1) {
+					  out.write(outdata, 0, len);
+				  }
+				  out.close();
+			  }
+			    
+			}
+		  zis.close();
+		  HttpHeaders httpHeaders = new HttpHeaders();
+		    httpHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+		    httpHeaders.setContentLength(out.toByteArray().length);
+		    httpHeaders.setContentDispositionFormData("attachment", filepath);
+		    return new ResponseEntity<>(out.toByteArray(), httpHeaders, HttpStatus.OK);
+	
+	  
+
+	  }catch(NullPointerException ne){
+		  throw ne;
+	  }
+	  catch(Exception e){
+	    throw e;
+	  }
+	 
+  }
+  
+  
 }


### PR DESCRIPTION
As discussed and called for in [ODD-541](http://mml.nist.gov:8080/browse/ODD-541), this PR represents a variation on the [feature/ODD-491 branch](https://github.com/usnistgov/oar-dist-service/tree/feature/ODD-491) on the distribution service.  It implements the 2 recommendations from [ODD-541](http://mml.nist.gov:8080/browse/ODD-541):
* restore the download-all implementation from prior to the [feature/ODD-491 branch](https://github.com/usnistgov/oar-dist-service/tree/feature/ODD-491)
* when downloading single files, remove the step where bags are copied into the cache; instead read them directly from the preservation bucket.

This PR was tested on oardev.