### PR TITLE
Fix/timeout

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ server:
     contextPath: /oar-dist-service
     error:
       include-stacktrace: never
-    connection-timeout: 60000
+    connection-timeout: 120000
     max-http-header-size: 8192
     tomcat:
       accesslog:

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -12,7 +12,7 @@ server:
     contextPath: /oar-dist-service
     error:
       include-stacktrace: never
-    connection-timeout: 120000
+    connection-timeout: 300000
     max-http-header-size: 8192
     tomcat:
       accesslog:


### PR DESCRIPTION
Increased time out to 300s as its taking long for a bigger data set to download.
This is a temporary fix. We will try and update the service later.