### PR TITLE
Fix/odd 611 file download extention avoid sha

### DIFF
--- a/src/main/java/gov/nist/oar/ds/config/S3Config.java
+++ b/src/main/java/gov/nist/oar/ds/config/S3Config.java
@@ -39,7 +39,7 @@ public class S3Config {
   private static Logger log = LoggerFactory.getLogger(S3Config.class);
 
   @Bean
-  @Profile({"prod", "dev", "test"})
+  @Profile({"prod", "test", "dev"})
   public AmazonS3Client s3Client() {
     log.info("Creating s3 client instance");
     InstanceProfileCredentialsProvider provider = new InstanceProfileCredentialsProvider();

--- a/src/main/java/gov/nist/oar/ds/exception/ResourceNotFoundException.java
+++ b/src/main/java/gov/nist/oar/ds/exception/ResourceNotFoundException.java
@@ -43,7 +43,6 @@ public class ResourceNotFoundException extends RuntimeException {
 	 * @param requestUrl String
 	 */
 	public ResourceNotFoundException(String requestUrl){
-		
 		super("Resource you are looking for is not available.");
 		this.setRequestUrl(requestUrl);
 	}

--- a/src/main/java/gov/nist/oar/ds/s3/S3Wrapper.java
+++ b/src/main/java/gov/nist/oar/ds/s3/S3Wrapper.java
@@ -164,6 +164,7 @@ public class S3Wrapper {
    * @return
    */
   public List<S3ObjectSummary> list(String bucket, String prefix) {
+	
     ObjectListing objectListing =
         s3Client.listObjects(new ListObjectsRequest().withBucketName(bucket).withPrefix(prefix));
     return objectListing.getObjectSummaries();

--- a/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
+++ b/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
@@ -410,10 +410,21 @@ public class DownloadServiceImpl implements DownloadService {
 		 this.validateIds(recordid, "Record or DataSet identifier");
 		 this.validateIds(filepath, "file path");
 	  
-	     List<S3ObjectSummary> files = s3Wrapper.list(preservationBucket, recordid);
+	     List<S3ObjectSummary> files = new ArrayList<S3ObjectSummary>();
+	     logger.info("TEST HERE 1: "+recordid +" :: "+filepath+" :: preservationBucket::"+preservationBucket);
+	     logger.error("TEST HERE 2: "+recordid +" :: "+filepath +" :: preservationBucket::"+preservationBucket);
+	     try{
+	    	 files = s3Wrapper.list(preservationBucket, recordid);
+	    	 
+	     }catch(Exception exp){
+	    	 logger.info("There is an error::"+exp.getMessage());
+	    	 logger.error("Exception here::"+exp.getMessage());
+	     }
  
-	     if(files.isEmpty()) 
-	    	  throw new ResourceNotFoundException("No data available for given id.");
+	     if(files.isEmpty()) {
+	    	 logger.error("No data available for given id.");
+	    	 throw new ResourceNotFoundException("No data available for given id.");
+	     }
 	  
 	     String recordBagKey = files.get(files.size()-1).getKey();
 		  
@@ -423,8 +434,11 @@ public class DownloadServiceImpl implements DownloadService {
 		 ByteArrayOutputStream out = new ByteArrayOutputStream();
 //		  if(!s3Wrapper.doesObjectExistInCache(cacheBucket, recordBagKey))
 //			  s3Wrapper.copytocache(preservationBucket, recordBagKey, cacheBucket,recordBagKey);
-
-          logger.debug("Pulling data from bucket="+preservationBucket);
+		 logger.info("Pulling data from bucket 1="+preservationBucket +" recordbagkey:"+recordBagKey + " :: "
+		 		+ " filename ::"+filename );
+          logger.debug("Pulling data from bucket 2="+preservationBucket+" recordbagkey:"+recordBagKey + " :: "
+  		 		+ " filename ::"+filename);
+          
 		  ResponseEntity<byte[]> zipdata = s3Wrapper.download(preservationBucket,recordBagKey);
 		  ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipdata.getBody()));
 		  ZipEntry entry; 

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -27,8 +27,11 @@ security:
     enable-csrf: false
     
      
+    
 logging:
-  path : /var/log/dist-service/
+  file: dist-service.log
+  path : /var/log/dist-service
+  exception-conversion-word: '%wEx'
     
     
     

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
 
 <appender name="SAVE-TO-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-  <file>/var/log/dist-service/distservice.log</file>
+  <file>${LOG_PATH}/distservice.log</file>
 
   <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
     <Pattern>
@@ -18,7 +18,7 @@
 
   <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
     <fileNamePattern>
-      /var/log/dist-service/distservice_%i.log
+      ${LOG_PATH}/distservice_%i.log
     </fileNamePattern>
     <minIndex>2</minIndex>
     <maxIndex>100</maxIndex>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
 
 <appender name="SAVE-TO-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-  <file>${LOG_PATH}/distservice.log</file>
+  <file>/var/log/dist-service/distservice.log</file>
 
   <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
     <Pattern>
@@ -18,7 +18,7 @@
 
   <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
     <fileNamePattern>
-      ${LOG_PATH}/distservice_%i.log
+      /var/log/dist-service/distservice_%i.log
     </fileNamePattern>
     <minIndex>2</minIndex>
     <maxIndex>100</maxIndex>
@@ -41,4 +41,3 @@
     </root>
 
 </configuration>
-


### PR DESCRIPTION
[ODD-611](http://mml.nist.gov:8080/browse/ODD-611)

Single file download had an issue when there were .sha files present along with bag(.zip) files.
Distribution service was throwing the exception that resource not found because it was looking into .sha file.
Updated function to check file extension in given preservation bucket before pulling out data from the bag. 
example:
https://oardev.nist.gov/od/ds/6576C69624E31C71E053245706815C531891/state-detector_tomography.pdf
