### PR TITLE
AWS Access errors indicate unclosed streams

### DIFF
--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -188,6 +188,7 @@ public void downloadData(@PathVariable("dsId") String dsid, HttpServletRequest r
                          HttpServletResponse response)
     throws IOException
 {
+    logger.debug("Handling file request having PATH_INFO=" + request.getPathInfo());
     logger.debug("Handling file request from dataset with id=" + dsid);
   
     String restOfTheUrl = (String) request.getAttribute(

--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -188,7 +188,11 @@ public void downloadData(@PathVariable("dsId") String dsid, HttpServletRequest r
                          HttpServletResponse response)
     throws IOException
 {
-    logger.debug("Handling file request having PATH_INFO=" + request.getPathInfo());
+    logger.debug("Handling file request having \n"+
+                   "   PATH_INFO=" +   request.getPathInfo() +
+                 "\n   request uri=" + request.getRequestURI() +
+                 "\n   request cxt=" + request.getRequestContext() 
+                 );
     logger.debug("Handling file request from dataset with id=" + dsid);
   
     String restOfTheUrl = (String) request.getAttribute(

--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -188,11 +188,6 @@ public void downloadData(@PathVariable("dsId") String dsid, HttpServletRequest r
                          HttpServletResponse response)
     throws IOException
 {
-    logger.debug("Handling file request having \n"+
-                   "   PATH_INFO=" +   request.getPathInfo() +
-                 "\n   request uri=" + request.getRequestURI() +
-                 "\n   request cxt=" + request.getContextPath() 
-                 );
     logger.debug("Handling file request from dataset with id=" + dsid);
   
     String restOfTheUrl = (String) request.getAttribute(
@@ -201,7 +196,7 @@ public void downloadData(@PathVariable("dsId") String dsid, HttpServletRequest r
     restOfTheUrl = restOfTheUrl.replace("/"+dsid+"/", "");
     logger.info("Handling request for data file: id="+dsid+" path="+restOfTheUrl);
       
-    downloadService.downloadData(dsid, BagUtils.urlDecode(restOfTheUrl), response);
+    downloadService.downloadData(dsid, restOfTheUrl, response);
 }
 
 //@RequestMapping(value="/{id}/**", method = RequestMethod.GET)

--- a/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
+++ b/src/main/java/gov/nist/oar/ds/controller/DownloadController.java
@@ -191,7 +191,7 @@ public void downloadData(@PathVariable("dsId") String dsid, HttpServletRequest r
     logger.debug("Handling file request having \n"+
                    "   PATH_INFO=" +   request.getPathInfo() +
                  "\n   request uri=" + request.getRequestURI() +
-                 "\n   request cxt=" + request.getRequestContext() 
+                 "\n   request cxt=" + request.getContextPath() 
                  );
     logger.debug("Handling file request from dataset with id=" + dsid);
   

--- a/src/main/java/gov/nist/oar/ds/s3/S3Wrapper.java
+++ b/src/main/java/gov/nist/oar/ds/s3/S3Wrapper.java
@@ -141,7 +141,12 @@ public class S3Wrapper {
   public InputStream streamFile(String bucket, String key) throws IOException {
     GetObjectRequest getObjectRequest = new GetObjectRequest(bucket, key);
     S3Object s3Object = s3Client.getObject(getObjectRequest);
-    return s3Object.getObjectContent();
+    try {
+        return s3Object.getObjectContent();
+    } catch (Exception ex) {
+        s3Object.close();
+        throw ex;
+    }
   }
   
   public void copytocache(String hostbucket, String hostkey, String destBucket, String destKey){

--- a/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
+++ b/src/main/java/gov/nist/oar/ds/service/impl/DownloadServiceImpl.java
@@ -485,8 +485,8 @@ public class DownloadServiceImpl implements DownloadService {
       throws IOException
   {
 	  this.validateIds(recordid, "Record or DataSet identifier");
-	  this.validateIds(filepath, "file path");
-	  logger.info("Info : record id: "+recordid +" :: "+filepath+" :: preservationBucket::"+preservationBucket);
+          this.validateIds(filepath, "file path");
+          logger.info("Info : record id: "+recordid +" :: "+filepath+" :: preservationBucket::"+preservationBucket);
 	  
 	  String headbag = extractRecordkey(recordid);
           String recordBagKey = lookupFile(headbag, recordid, filepath);
@@ -515,16 +515,19 @@ public class DownloadServiceImpl implements DownloadService {
                       }
                       response.flushBuffer();
                       logger.info(filepath + " sent.");
+                      zipdata.close();
                       return;
                   }
                   catch (org.apache.catalina.connector.ClientAbortException ex) {
                       logger.info("Client cancelled the download");
                       // response.flushBuffer();
+                      zipdata.close();
                       return;
                   }
                   catch (IOException ex) {
                       logger.info("IOException type: "+ex.getClass().getName());
-
+                      zipdata.close();
+                      
                       // "Connection reset by peer" gets thrown if the user cancels the download
                       if (ex.getMessage().contains("Connection reset by peer"))
                           logger.info("Client cancelled download");
@@ -533,6 +536,7 @@ public class DownloadServiceImpl implements DownloadService {
                   }
               }
           }
+          zipdata.close();
 
           throw new ResourceNotFoundException("Failed to find file, "+filepath+" in bag, "+headbag,
                                               recordid);


### PR DESCRIPTION
The distribution service was throwing exceptions that would cease the ability to download file, exceptions that suggested that streams that pull data from AWS were not being closed.  Sure enough, the `downloadData()` was not closing its input streams, so this PR fixes this issue.  