### PR TITLE
Replace use of localstack with S3Mock

### DIFF
--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -4,13 +4,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y netcat-openbsd zi
                                             gnupg python python-pip python-virtualenv \
                                             make gcc curl maven
 
-# npm is need by localstack, but we need a newer version than what is available 
-# from debian
-# 
-RUN (curl -sL https://deb.nodesource.com/setup_8.x | bash -) && \
-     apt-get install -y nodejs
-
-
 # ARG gosu_arch=
 # ENV GOSU_ARCH $gosu_arch
 # ENV GOSU_VERSION 1.10
@@ -52,20 +45,6 @@ RUN chmod a+rx /app/entrypoint.sh
 
 WORKDIR /app/dev
 USER $devuser
-
-# Now install localstack as the user who's going to use it
-#
-# Download localstack for use via maven to test AWS accessing classes
-# as of 09-20-2018:
-# 
-RUN (set -ex; LS_HASH=70edd81fd9cd21aea4cb388d22aba377bd63a96b; \
-     curl -L -o /tmp/localstack-$LS_HASH.zip \
-     https://github.com/localstack/localstack/archive/$LS_HASH.zip; \
-     cd /tmp; ls -l localstack-$LS_HASH.zip; \
-     unzip -q localstack-$LS_HASH.zip; mv localstack-$LS_HASH localstack_install_dir)
-
-RUN (cd /tmp/localstack_install_dir; make install)
-
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
             <artifactId>localstack-utils</artifactId>
             <version>0.1.14</version>
         </dependency>
+        <dependency>
+            <groupId>io.findify</groupId>
+            <artifactId>s3mock_2.12</artifactId>
+            <version>0.2.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -130,14 +130,9 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
-            <groupId>cloud.localstack</groupId>
-            <artifactId>localstack-utils</artifactId>
-            <version>0.1.14</version>
-        </dependency>
-        <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>
-            <version>0.2.4</version>
+            <version>0.2.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/gov/nist/oar/distrib/storage/AWSS3LongTermStorageTest.java
+++ b/src/test/java/gov/nist/oar/distrib/storage/AWSS3LongTermStorageTest.java
@@ -32,8 +32,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 
 import gov.nist.oar.distrib.Checksum;
 import gov.nist.oar.distrib.LongTermStorage;
@@ -53,18 +57,22 @@ public class AWSS3LongTermStorageTest {
   
     private static Logger logger = LoggerFactory.getLogger(FilesystemLongTermStorageTest.class);
 
+    static int port = 9001;
     static final String bucket = "oar-lts-test";
     static String hash = "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9";
-    static S3Mock api = new S3Mock.Builder().withPort(9001).withInMemoryBackend().build();
+    static S3Mock api = new S3Mock.Builder().withPort(port).withInMemoryBackend().build();
     static AmazonS3 s3client = null;
     AWSS3LongTermStorage s3Storage = null;
   
     @BeforeClass
     public static void setUpClass() throws IOException {
+        String endpoint = "http://localhost:"+Integer.toString(port);
         api.start();
         s3client = AmazonS3ClientBuilder.standard()
                                         .withPathStyleAccessEnabled(true)  
-                                        .withEndpointConfiguration(endpoint)
+                                        .withEndpointConfiguration(
+                                                 new AwsClientBuilder.EndpointConfiguration(endpoint,
+                                                                                            "us-east-1"))
                                         .withCredentials(new AWSStaticCredentialsProvider(
                                                                       new AnonymousAWSCredentials()))
                                         .build();
@@ -88,6 +96,7 @@ public class AWSS3LongTermStorageTest {
     @AfterClass
     public static void tearDownClass() {
         destroyBucket();
+        api.shutdown();
     }
 
     public static void destroyBucket() {


### PR DESCRIPTION
This repo features one test class, `AWSS3LongTermStorageTest` that requires mocking the AWS S3 service for use by the `AWSS3LongTermStorage` class.  Previously the [localstack](https://localstack.cloud/) package provided this functionality; however, this has proved to be a fairly heavy-weight solution that can be slow (during automatic installation) and prone to failure (e.g. if `/tmp` is not big enough).  [S3Mock](https://github.com/findify/s3mock) is a lighter-weight alternative.  This PR replaces use of localstack with S3Mock.  

To test, simply run the unit tests (either via `scripts/testall`, `scripts/testall.docker`, or `mvn test`).  This, of course, is what TravisCI does, so noting that Travis is passing below should be sufficient.  