### PR TITLE
Swagger Endpoint and document link

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/web/AIPAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/AIPAccessController.java
@@ -66,7 +66,7 @@ import springfox.documentation.annotations.ApiIgnore;
  */
 @RestController
 @Api
-@RequestMapping(value = "/ds/_aip")
+@RequestMapping(value = "/_aip")
 public class AIPAccessController {
 
     Logger logger = LoggerFactory.getLogger(AIPAccessController.class);

--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -73,7 +73,7 @@ import springfox.documentation.annotations.ApiIgnore;
  */
 @RestController
 @Api
-@RequestMapping(value = "/ds")
+//@RequestMapping(value = "/")
 public class DatasetAccessController {
 
     Logger logger = LoggerFactory.getLogger(DatasetAccessController.class);
@@ -301,13 +301,14 @@ public class DatasetAccessController {
 
         String filepath = (String) request.getAttribute(
                                       HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-        filepath = filepath.substring("/ds/".length() + dsid.length() + 1);
+        filepath = filepath.substring( dsid.length() + 2);
 
         String ver = null;
         if (filepath.startsWith("_v/")) {
             filepath = filepath.substring(3);
             int i = filepath.indexOf('/');
-            if (i >= 0) filepath = filepath.substring(i+1);
+            if (i >= 0) 
+        	filepath = filepath.substring(i+1);
         }
         checkFilePath(filepath);
 

--- a/src/main/java/gov/nist/oar/distrib/web/VersionController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/VersionController.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.Api;
  */
 @RestController
 @Api
-@RequestMapping(value = "/ds")
+@RequestMapping(value = "/")
 public class VersionController {
 
     /**
@@ -80,15 +80,15 @@ public class VersionController {
         return new VersionInfo(NAME, VERSION);
     }
 
-    /**
-     * redirect "/ds" to "/ds/"
-     */
-    @ApiOperation(value = "Return the version data for the service", nickname = "getServiceVersion",
-                  notes = "This returns the name and version label for this service")
-    @GetMapping(value = "")
-    public void redirectToServiceVersion(HttpServletResponse resp) throws IOException {
-        resp.sendRedirect("ds/");
-    }
+//    /**
+//     * redirect "/ds" to "/ds/"
+//     */
+//    @ApiOperation(value = "Return the version data for the service", nickname = "getServiceVersion",
+//                  notes = "This returns the name and version label for this service")
+//    @GetMapping(value = "")
+//    public void redirectToServiceVersion(HttpServletResponse resp) throws IOException {
+//        resp.sendRedirect("ds/");
+//    }
 
     public static class VersionInfo {
         public String serviceName = null;

--- a/src/main/java/gov/nist/oar/distrib/web/VersionController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/VersionController.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.Api;
  */
 @RestController
 @Api
-@RequestMapping(value = "/")
+//@RequestMapping(value = "/")
 public class VersionController {
 
     /**
@@ -75,7 +75,7 @@ public class VersionController {
      */
     @ApiOperation(value = "Return the version data for the service", nickname = "getServiceVersion",
                   notes = "This returns the name and version label for this service")
-    @GetMapping(value = "/")
+    @GetMapping(value = "")
     public VersionInfo getServiceVersion() {
         return new VersionInfo(NAME, VERSION);
     }

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -10,7 +10,7 @@ spring:
 server:
     port: 8083
     servlet:
-      context-path:  /oar-dist-service
+      context-path:  /od/ds
     error:
       include-stacktrace: never
     connection-timeout: 300000
@@ -31,7 +31,7 @@ security:
     
 logging:
   file: distservice.log
-  path : /var/log/dist-service
+  path : /tmp/dist
   exception-conversion-word: '%wEx'
 
 

--- a/src/test/java/gov/nist/oar/distrib/web/AIPAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/AIPAccessControllerTest.java
@@ -65,7 +65,7 @@ public class AIPAccessControllerTest {
     public void testDescribeAIP() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() +
-                                                          "/ds/_aip/mds1491.mbag0_2-0.zip/_info",
+                                                          "/_aip/mds1491.mbag0_2-0.zip/_info",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -83,10 +83,10 @@ public class AIPAccessControllerTest {
     @Test
     public void testDescribeAIPsBadID() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/_aip/goober.zip",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/_aip/goober.zip",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/_aip/goober.zip\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/_aip/goober.zip\"," +
                                  "status:404,message:\"AIP file not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -95,7 +95,7 @@ public class AIPAccessControllerTest {
     public void testDownloadAIP() {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() +
-                                                          "/ds/_aip/mds1491.mbag0_2-0.zip",
+                                                          "/_aip/mds1491.mbag0_2-0.zip",
                                                       HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());
@@ -104,6 +104,6 @@ public class AIPAccessControllerTest {
     }
 
     private String getBaseURL() {
-        return "http://localhost:" + port + "/oar-dist-service";
+        return "http://localhost:" + port + "/od/ds";
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
@@ -63,13 +63,13 @@ public class DatasetAccessControllerTest {
     HttpHeaders headers = new HttpHeaders();
 
     private String getBaseURL() {
-        return "http://localhost:" + port + "/oar-dist-service";
+        return "http://localhost:" + port + "/od/ds";
     }
 
     @Test
     public void testDescribeAIPs() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/_aip",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -84,10 +84,10 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDescribeAIPsBadID() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/goober/_aip",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -96,7 +96,7 @@ public class DatasetAccessControllerTest {
     public void testDescribeAIPsEvil() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() +
-                                                      "/ds/%3Cscript%3Egoober%3C%2Fscript%3E/_aip",
+                                                      "/%3Cscript%3Egoober%3C%2Fscript%3E/_aip",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         assertFalse(resp.getBody().contains("script>"));
@@ -107,7 +107,7 @@ public class DatasetAccessControllerTest {
     @Test
     public void testListAIPVersions() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_v",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -119,10 +119,10 @@ public class DatasetAccessControllerTest {
     @Test
     public void testListAIPVersionsBadID() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip/_v",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/goober/_aip/_v",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip/_v\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip/_v\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -130,7 +130,7 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDescribeAIPsForVersion() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v/0",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_v/0",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -141,7 +141,7 @@ public class DatasetAccessControllerTest {
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
 
         
-        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v/1.1.0",
+        resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_v/1.1.0",
                                HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -156,7 +156,7 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDescribeHeadAIPForVersion() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v/0/_head",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_v/0/_head",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -167,7 +167,7 @@ public class DatasetAccessControllerTest {
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
 
         
-        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v/1.1.0/_head",
+        resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_v/1.1.0/_head",
                                HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -182,18 +182,18 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDescribeAIPsForVersionBadIn() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip/_v/0",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/goober/_aip/_v/0",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip/_v/0\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip/_v/0\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
 
         req = new HttpEntity<String>(null, headers);
-        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v/12.32",
+        resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_v/12.32",
                                HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/_aip/_v/12.32\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/_aip/_v/12.32\"," +
                            "status:404,message:\"Requested version of resource not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -201,7 +201,7 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDdescribeLatestHeadAIP() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_head",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/_aip/_head",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -215,10 +215,10 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDescribeHeadAIPForVersionBadInp() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip/_head",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/goober/_aip/_head",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip/_head\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip/_head\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
 
@@ -227,7 +227,7 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDownloadFile() {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/trial1.json",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/trial1.json",
                                                       HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());
@@ -238,23 +238,23 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDownloadFileBadInp() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/trial1.json",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/goober/trial1.json",
                                                       HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/trial1.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/trial1.json\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
 
 
         req = new HttpEntity<String>(null, headers);
-        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/goober/trial1.json",
+        resp = websvc.exchange(getBaseURL() + "/mds1491/goober/trial1.json",
                                HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/goober/trial1.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/goober/trial1.json\"," +
                                  "status:404,message:\"File not found in requested dataset\",method:GET}",
                                 resp.getBody(), true);
 
@@ -263,12 +263,12 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDownloadFileMalInp() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goob er/trial1.json",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/goob er/trial1.json",
                                                       HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goob%20er/trial1.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goob%20er/trial1.json\"," +
                                  "status:400,message:\"Malformed input\",method:GET}",
                                 resp.getBody(), true);
 
@@ -288,12 +288,12 @@ public class DatasetAccessControllerTest {
         */
 
         req = new HttpEntity<String>(null, headers);
-        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/.trial3a.json",
+        resp = websvc.exchange(getBaseURL() + "/mds1491/.trial3a.json",
                                HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/.trial3a.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/.trial3a.json\"," +
                                  "status:400,message:\"Malformed input\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -301,7 +301,7 @@ public class DatasetAccessControllerTest {
     @Test
     public void testDownloadFileFromVersion() {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_v/0/trial1.json",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/mds1491/_v/0/trial1.json",
                                                       HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());
@@ -309,7 +309,7 @@ public class DatasetAccessControllerTest {
         assertEquals(69, resp.getBody().length());
 
         req = new HttpEntity<String>(null, headers);
-        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_v/1.1.0/trial1.json",
+        resp = websvc.exchange(getBaseURL() + "/mds1491/_v/1.1.0/trial1.json",
                                HttpMethod.GET, req, String.class);
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());

--- a/src/test/java/gov/nist/oar/distrib/web/VersionControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/VersionControllerTest.java
@@ -51,13 +51,13 @@ public class VersionControllerTest {
     HttpHeaders headers = new HttpHeaders();
 
     private String getBaseURL() {
-        return "http://localhost:" + port + "/oar-dist-service";
+        return "http://localhost:" + port + "/od/ds";
     }
 
     @Test
     public void testGetServiceVersion() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
@@ -74,16 +74,16 @@ public class VersionControllerTest {
     @Test
     public void testDeleteNotAllowed() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/",
                                                       HttpMethod.DELETE, req, String.class);
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED, resp.getStatusCode());
 
         req = new HttpEntity<String>(null, headers);
-        resp = websvc.exchange(getBaseURL() + "/ds/", HttpMethod.POST, req, String.class);
+        resp = websvc.exchange(getBaseURL() + "/", HttpMethod.POST, req, String.class);
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED, resp.getStatusCode());
 
         req = new HttpEntity<String>(null, headers);
-        resp = websvc.exchange(getBaseURL() + "/ds/", HttpMethod.PATCH, req, String.class);
+        resp = websvc.exchange(getBaseURL() + "/", HttpMethod.PATCH, req, String.class);
         assertEquals(HttpStatus.METHOD_NOT_ALLOWED, resp.getStatusCode());
     }
 
@@ -91,19 +91,19 @@ public class VersionControllerTest {
     @Test
     public void testHEAD() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/",
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/",
                                                       HttpMethod.HEAD, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
     }
     
-    @Test
-    public void testRedirectToServiceVersion() throws JSONException {
-        HttpEntity<String> req = new HttpEntity<String>(null, headers);
-        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds",
-                                                      HttpMethod.GET, req, String.class);
-        assertEquals(HttpStatus.FOUND, resp.getStatusCode());
-
-        assertTrue(resp.getHeaders().getFirst("Location").endsWith("/oar-dist-service/ds/"));
-    }
+//    @Test
+//    public void testRedirectToServiceVersion() throws JSONException {
+//        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+//        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/",
+//                                                      HttpMethod.GET, req, String.class);
+//        assertEquals(HttpStatus.FOUND, resp.getStatusCode());
+//
+//        assertTrue(resp.getHeaders().getFirst("Location").endsWith("/od/ds/"));
+//    }
 
 }


### PR DESCRIPTION
Updated context path to /od/ds  in the application to match with the reverse proxy.
Removed request mapping /ds in the api endpoints.

Issue and Solution:
Swagger documentation configuration uses baseurl which is context path set up in the application properties. We were overwriting this context path in proxy server settings, which was creating conflict and swagger documentation was never working. 
Now the swagger api documentation in json format can be accessed by using
https://<any host>/od/ds/v2/api-docs
