### PR TITLE
Make swagger API documentation available

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -10,7 +10,7 @@ spring:
 server:
     port: 8083
     servlet:
-      context-path:  /oar-dist-service
+      context-path:  /od
     error:
       include-stacktrace: never
     connection-timeout: 300000

--- a/src/test/java/gov/nist/oar/distrib/web/AIPAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/AIPAccessControllerTest.java
@@ -86,7 +86,7 @@ public class AIPAccessControllerTest {
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/_aip/goober.zip",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/_aip/goober.zip\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/_aip/goober.zip\"," +
                                  "status:404,message:\"AIP file not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -104,6 +104,6 @@ public class AIPAccessControllerTest {
     }
 
     private String getBaseURL() {
-        return "http://localhost:" + port + "/oar-dist-service";
+        return "http://localhost:" + port + "/od";
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
@@ -63,7 +63,7 @@ public class DatasetAccessControllerTest {
     HttpHeaders headers = new HttpHeaders();
 
     private String getBaseURL() {
-        return "http://localhost:" + port + "/oar-dist-service";
+        return "http://localhost:" + port + "/od";
     }
 
     @Test
@@ -87,7 +87,7 @@ public class DatasetAccessControllerTest {
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -122,7 +122,7 @@ public class DatasetAccessControllerTest {
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip/_v",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip/_v\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip/_v\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -185,7 +185,7 @@ public class DatasetAccessControllerTest {
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip/_v/0",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip/_v/0\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip/_v/0\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
 
@@ -193,7 +193,7 @@ public class DatasetAccessControllerTest {
         resp = websvc.exchange(getBaseURL() + "/ds/mds1491/_aip/_v/12.32",
                                HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/_aip/_v/12.32\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/_aip/_v/12.32\"," +
                            "status:404,message:\"Requested version of resource not found\",method:GET}",
                                 resp.getBody(), true);
     }
@@ -218,7 +218,7 @@ public class DatasetAccessControllerTest {
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/_aip/_head",
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/_aip/_head\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/_aip/_head\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
 
@@ -243,7 +243,7 @@ public class DatasetAccessControllerTest {
 
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goober/trial1.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goober/trial1.json\"," +
                                  "status:404,message:\"Resource ID not found\",method:GET}",
                                 resp.getBody(), true);
 
@@ -254,7 +254,7 @@ public class DatasetAccessControllerTest {
 
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/goober/trial1.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/goober/trial1.json\"," +
                                  "status:404,message:\"File not found in requested dataset\",method:GET}",
                                 resp.getBody(), true);
 
@@ -268,7 +268,7 @@ public class DatasetAccessControllerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/goob%20er/trial1.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/goob%20er/trial1.json\"," +
                                  "status:400,message:\"Malformed input\",method:GET}",
                                 resp.getBody(), true);
 
@@ -282,7 +282,7 @@ public class DatasetAccessControllerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/trial3/../trial3/trial3a.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/trial3/../trial3/trial3a.json\"," +
                                  "status:400,message:\"Malformed input\",method:GET}",
                                 resp.getBody(), true);
         */
@@ -293,7 +293,7 @@ public class DatasetAccessControllerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
-        JSONAssert.assertEquals("{requestURL:\"/oar-dist-service/ds/mds1491/.trial3a.json\"," +
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/.trial3a.json\"," +
                                  "status:400,message:\"Malformed input\",method:GET}",
                                 resp.getBody(), true);
     }

--- a/src/test/java/gov/nist/oar/distrib/web/NISTDistribServiceConfigTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/NISTDistribServiceConfigTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
 @TestPropertySource(properties = {
         "distrib.bagstore.mode=local",
         "distrib.bagstore.location=${basedir}/src/test/resources",
-        "distrib.baseurl=http://localhost/oar-dist-service"
+        "distrib.baseurl=http://localhost/od"
 })
 public class NISTDistribServiceConfigTest {
 

--- a/src/test/java/gov/nist/oar/distrib/web/VersionControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/VersionControllerTest.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 @TestPropertySource(properties = {
         "distrib.bagstore.mode=local",
         "distrib.bagstore.location=${basedir}/src/test/resources",
-        "distrib.baseurl=http://localhost/oar-distrb-service",
+        "distrib.baseurl=http://localhost/od",
         "cloud.aws.region=us-east-1",
         "logging.path=${basedir}/target/surefire-reports",
 })
@@ -51,7 +51,7 @@ public class VersionControllerTest {
     HttpHeaders headers = new HttpHeaders();
 
     private String getBaseURL() {
-        return "http://localhost:" + port + "/oar-dist-service";
+        return "http://localhost:" + port + "/od";
     }
 
     @Test
@@ -103,7 +103,7 @@ public class VersionControllerTest {
                                                       HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.FOUND, resp.getStatusCode());
 
-        assertTrue(resp.getHeaders().getFirst("Location").endsWith("/oar-dist-service/ds/"));
+        assertTrue(resp.getHeaders().getFirst("Location").endsWith("/od/ds/"));
     }
 
 }


### PR DESCRIPTION
This is an alternative solution presented PR #56 which aimed to make the distribution services swagger document accessible through the proxy server that is part of [oar-docker](https://github.com/usnistgov/oar-docker).  This documentation is helpful to our A&A process (see [ODD-726](http://mml.nist.gov:8080/browse/ODD-726)).  PR #56 successfully exposes the JSON documentation, but not the HTML; this PR exposes both documents and ensures that the URLs to the service enpoints presented in the documents are correct with respect to the proxy server.

The solution requires both this PR and a corresponding [PR#109 in oar-docker](/usnistgov/oar-docker/pull/109).  This PR simply changes the context path for the service from `/oar-dist-service` to `/od`; this ensures correct URLs with the documentation.  The oar-docker PR creates a routing path `/od/ds-api` specifically for requesting the swagger documents: e.g. the path `/od/ds-api/swagger-ui.html` returns the HTML swagger document, and `/od/ds-api/v2/api-docs/` returns the JSON document.  

This PR is best tested via the oar-docker PR; see that PR for more information.