### PR TITLE
Fix/odd 735 update bundle info.txt

### DIFF
--- a/src/test/java/gov/nist/oar/distrib/service/DefaultDataPackagingServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/DefaultDataPackagingServiceTest.java
@@ -12,14 +12,14 @@
  */
 package gov.nist.oar.distrib.service;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -29,7 +29,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -44,7 +43,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.nist.oar.distrib.DistributionException;
 import gov.nist.oar.distrib.InputLimitException;
-import gov.nist.oar.distrib.datapackage.DefaultDataPackager;
 import gov.nist.oar.distrib.web.objects.BundleRequest;
 import gov.nist.oar.distrib.web.objects.FileRequest;
 
@@ -91,25 +89,23 @@ public class DefaultDataPackagingServiceTest {
 
     @Test
     public void getBundledZip() throws DistributionException, InputLimitException, IOException {
-	
-	    String bundleName = "example";
-	    ddp.validateRequest(bundleRequest);
-	    if (!bundleRequest.getBundleName().isEmpty() && bundleRequest.getBundleName() != null)
-		bundleName = bundleRequest.getBundleName();
 
-	    Path path = Files.createTempFile(bundleName, ".zip");
-	    OutputStream os = Files.newOutputStream(path);
-	    ZipOutputStream zos = new ZipOutputStream(os);
-	    ddp.getBundledZipPackage(bundleRequest, zos);
-	    zos.close();
-	    int len = (int) Files.size(path);
-	    System.out.println("Len:" + len);
-	    // assertEquals(len, 59903);
-	    assertNotNull(zos);
-	    checkFilesinZip(path);
-	    Files.delete(path);
+	String bundleName = "example";
+	ddp.validateRequest(bundleRequest);
+	if (!bundleRequest.getBundleName().isEmpty() && bundleRequest.getBundleName() != null)
+	    bundleName = bundleRequest.getBundleName();
 
-	
+	Path path = Files.createTempFile(bundleName, ".zip");
+	OutputStream os = Files.newOutputStream(path);
+	ZipOutputStream zos = new ZipOutputStream(os);
+	ddp.getBundledZipPackage(bundleRequest, zos);
+	zos.close();
+	int len = (int) Files.size(path);
+	System.out.println("Len:" + len);
+	// assertEquals(len, 59903);
+	assertNotNull(zos);
+	checkFilesinZip(path);
+	Files.delete(path);
 
     }
 
@@ -138,6 +134,8 @@ public class DefaultDataPackagingServiceTest {
 	    assertEquals(count, 3);
 
 	} catch (IOException ixp) {
+	    logger.error(
+		    "There is an error while reading zip file contents in the getBundleZip test." + ixp.getMessage());
 	    throw ixp;
 	}
     }
@@ -201,11 +199,15 @@ public class DefaultDataPackagingServiceTest {
 		    try {
 			stream.close();
 		    } catch (Throwable ignore) {
+			logger.error(
+				"There is an error while closing stream of bundleInfo.txt, in the testBundleWithWarnings. "
+					+ ignore.getMessage());
 		    }
 		}
 
 	    }
 	} catch (IOException ixp) {
+	    logger.error("There is an error while reading bundled Zip in testBundleWithWarnings. " + ixp.getMessage());
 	    throw ixp;
 	}
 

--- a/src/test/java/gov/nist/oar/distrib/service/DefaultDataPackagingServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/DefaultDataPackagingServiceTest.java
@@ -90,8 +90,8 @@ public class DefaultDataPackagingServiceTest {
     public final ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void getBundledZip() throws DistributionException, InputLimitException {
-	try {
+    public void getBundledZip() throws DistributionException, InputLimitException, IOException {
+	
 	    String bundleName = "example";
 	    ddp.validateRequest(bundleRequest);
 	    if (!bundleRequest.getBundleName().isEmpty() && bundleRequest.getBundleName() != null)
@@ -109,14 +109,11 @@ public class DefaultDataPackagingServiceTest {
 	    checkFilesinZip(path);
 	    Files.delete(path);
 
-	} catch (IOException e) {
-	    // TODO Auto-generated catch block
-	    e.printStackTrace();
-	}
+	
 
     }
 
-    public void checkFilesinZip(Path filepath) {
+    public void checkFilesinZip(Path filepath) throws IOException {
 	int count = 0;
 	try (ZipFile file = new ZipFile(filepath.toString())) {
 	    FileSystem fileSystem = FileSystems.getDefault();
@@ -141,7 +138,7 @@ public class DefaultDataPackagingServiceTest {
 	    assertEquals(count, 3);
 
 	} catch (IOException ixp) {
-
+	    throw ixp;
 	}
     }
 
@@ -209,7 +206,7 @@ public class DefaultDataPackagingServiceTest {
 
 	    }
 	} catch (IOException ixp) {
-
+	    throw ixp;
 	}
 
     }

--- a/src/test/java/gov/nist/oar/distrib/web/DataBundleAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DataBundleAccessControllerTest.java
@@ -100,7 +100,7 @@ public class DataBundleAccessControllerTest {
 
 	assertEquals(HttpStatus.OK, response.getStatusCode());
 	assertTrue(response.getHeaders().getFirst("Content-Type").startsWith("application/zip"));
-	assertEquals(59903, response.getBody().length());
+	assertEquals(59899, response.getBody().length());
 
     }
 


### PR DESCRIPTION
This pull request addresses the issue [ODD-735](http://mml.nist.gov:8080/browse/ODD-735)
On any bundle request completion, bundleInfo.txt gets added in the bundle.
For this first version, we kept this file simple text file.
 
If there are no errors or warnings while creating bundle, it will simply put a message all files are added successfully in this bundle. The idea is in future we can put more metadata about bundle/files like size and description etc

If there are errors, it will list the file names and urls which has error accessing and not included in the bundle.

If there are warnings like, the non supported domain/url, it will be listed with filename and associated URLs

