### PR TITLE
Add custom HEAD handling for data files (to address hanging issue)

### DIFF
--- a/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
@@ -318,6 +318,17 @@ public class DatasetAccessControllerTest {
     }
 
     @Test
+    public void testDownloadFileInfo() {
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491/trial1.json",
+                                                      HttpMethod.HEAD, req, String.class);
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
+        assertNull(resp.getBody());
+    }
+
+    @Test
     public void testBadDatasetIDPattern() {
         assertTrue(DatasetAccessController.baddsid.matcher("goober gurn").find());
         assertTrue(DatasetAccessController.baddsid.matcher("goober\tgurn").find());


### PR DESCRIPTION
We've been seeing the distribution service hanging for unknown reasons, a behavior that appeared to be correlated with many HEAD requests on individual files from a robot client.  One possibility is related that these HEAD requests were being handled on the server-side as GET requests, which can be quite costly when the files get big.  It is possible that if several such big requests pile up, the service hangs.  In hopes of fixing this problem, this PR adds explicit support for HEAD requests that simply retrieves file metadata (namely, size and type) without actually extracting the file from its preservation bag.  

When fulfilling a HEAD request, the service will log a message indicating that file info was delivered; this message is different from the message when fulfilling a GET request; this is the indicator that the fix is in place and functioning.