### PR TITLE
ODD-756:  Correct runtime failure logging and S3 resource clean-up errors

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/service/FromBagFileDownloadService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/FromBagFileDownloadService.java
@@ -175,9 +175,21 @@ public class FromBagFileDownloadService implements FileDownloadService {
 
         // find the bag containing file, open the bag, find the file, set stream to file's start
         // (see openDataFile() and findDataFile())
-        ZipBagUtils.OpenEntry fentry = openDataFile(dsid, filepath, version);
-
-        return new FileDescription(filepath, fentry.info.getSize(), ct);
+        ZipBagUtils.OpenEntry fentry = null;
+        try {
+            fentry = openDataFile(dsid, filepath, version);
+            return new FileDescription(filepath, fentry.info.getSize(), ct);
+        }
+        finally {
+            if (fentry != null && fentry.stream != null) {
+                try {
+                    fentry.stream.close();
+                } catch (IOException ex) {
+                    logger.warn("Trouble closing zipfile stream for " + filepath +
+                                ": " + ex.getMessage());
+                }
+            }
+        }
     }
 
     private ZipBagUtils.OpenEntry openDataFile(String dsid, String filepath, String version)

--- a/src/main/java/gov/nist/oar/distrib/web/AIPAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/AIPAccessController.java
@@ -210,4 +210,14 @@ public class AIPAccessController {
         return new ErrorInfo(req.getRequestURI(), 500, "Internal Server Error");
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorInfo handleStreamingError(RuntimeException ex,
+                                          HttpServletRequest req)
+    {
+        logger.error("Unexpected failure during request: " + req.getRequestURI() +
+                     "\n  " + ex.getMessage(), ex);
+        return new ErrorInfo(req.getRequestURI(), 500, "Unexpected Server Error");
+    }
+
 }

--- a/src/main/java/gov/nist/oar/distrib/web/DataBundleAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DataBundleAccessController.java
@@ -155,4 +155,14 @@ public class DataBundleAccessController {
 	logger.info("Streaming failure during request: " + req.getRequestURI() + "\n  " + ex.getMessage());
 	return new ErrorInfo(req.getRequestURI(), 500, "Internal Server Error", "POST");
     }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorInfo handleStreamingError(RuntimeException ex,
+                                          HttpServletRequest req)
+    {
+        logger.error("Unexpected failure during request: " + req.getRequestURI() +
+                     "\n  " + ex.getMessage(), ex);
+        return new ErrorInfo(req.getRequestURI(), 500, "Unexpected Server Error");
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -365,6 +365,24 @@ public class DatasetAccessController {
         }
     }
 
+    /*
+     * trigger an error response.  This is normally disabled (commented out); it is engaged 
+     * only during development.
+     * 
+     * @param request   the input HTTP request object 
+     * @param response  the output HTTP response object, used to write the output data
+     * @throws IllegalStateException  always
+    @ApiOperation(value = "return (via the HTTP header) an HTTP error response",
+                  nickname = "return error")
+    @RequestMapping(value = "/_error/**", method=RequestMethod.GET)
+    public void testErrorHandling(@ApiIgnore HttpServletRequest request,
+                                  @ApiIgnore HttpServletResponse response)
+        throws ResourceNotFoundException, FileNotFoundException, DistributionException
+    {
+        throw new IllegalStateException("fake state");
+    }
+     */
+
     /**
      * download a data file information (via header fields).  This method responds to HEAD requests
      * on a downloadable file.  
@@ -475,7 +493,7 @@ public class DatasetAccessController {
     public ErrorInfo handleInternalError(DistributionException ex,
                                          HttpServletRequest req)
     {
-        logger.info("Failure processing request: " + req.getRequestURI() +
+        logger.warn("Failure processing request: " + req.getRequestURI() +
                     "\n  " + ex.getMessage());
         return new ErrorInfo(req.getRequestURI(), 500, "Internal Server Error");
     }
@@ -495,9 +513,19 @@ public class DatasetAccessController {
     public ErrorInfo handleStreamingError(DistributionException ex,
                                           HttpServletRequest req)
     {
-        logger.info("Streaming failure during request: " + req.getRequestURI() +
+        logger.warn("Streaming failure during request: " + req.getRequestURI() +
                     "\n  " + ex.getMessage());
         return new ErrorInfo(req.getRequestURI(), 500, "Internal Server Error");
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorInfo handleStreamingError(RuntimeException ex,
+                                          HttpServletRequest req)
+    {
+        logger.error("Unexpected failure during request: " + req.getRequestURI() +
+                     "\n  " + ex.getMessage(), ex);
+        return new ErrorInfo(req.getRequestURI(), 500, "Unexpected Server Error");
     }
 }
 

--- a/src/main/java/gov/nist/oar/distrib/web/VersionController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/VersionController.java
@@ -18,14 +18,21 @@ import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * a simple controller for revealing the version of the deployed service
@@ -36,6 +43,8 @@ import io.swagger.annotations.Api;
 @Api
 @RequestMapping(value = "/ds")
 public class VersionController {
+
+    Logger logger = LoggerFactory.getLogger(VersionController.class);
 
     /**
      * The service name
@@ -98,5 +107,15 @@ public class VersionController {
             serviceName = name;
             version = ver;
         }
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorInfo handleStreamingError(RuntimeException ex,
+                                          HttpServletRequest req)
+    {
+        logger.error("Unexpected failure during request: " + req.getRequestURI() +
+                     "\n  " + ex.getMessage(), ex);
+        return new ErrorInfo(req.getRequestURI(), 500, "Unexpected Server Error");
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/datapackage/ObjectUtilsTest.java
+++ b/src/test/java/gov/nist/oar/distrib/datapackage/ObjectUtilsTest.java
@@ -49,7 +49,7 @@ public class ObjectUtilsTest {
 
     @Test
     public void testGetUrlStatus() throws IOException {
-	String testurlError = "https://data.nist.gov/od/ds/69BEF4C29F700451E053B357068186906918/ngc0055%2B3.con.fits";
+	String testurlError = "https://www.nist.gov/does_not_exist.txt";
 	String testUrlRedirect = "http://www.nist.gov/srd/srd_data/srd13_B-049.json";
 	URL obj = new URL(testurlError);
 	HttpURLConnection connect = (HttpURLConnection) obj.openConnection();

--- a/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
@@ -341,4 +341,16 @@ public class DatasetAccessControllerTest {
         assertTrue(DatasetAccessController.badpath.matcher("goober/../../../gurn").find());
         assertFalse(DatasetAccessController.badpath.matcher("goober..gurn").find());
     }
+
+    /*
+     * see comment for DatasetAccessController.testErrorHandling()
+     *
+    @Test
+    public void testIllegalStateExceptionHndling() {
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/_error/goob",
+                                                      HttpMethod.GET, req, String.class);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+    }
+     */
 }


### PR DESCRIPTION
JIRA Issue ODD-756 noted that the distribution service was raising RuntimeExceptions but that the service controllers did not have exception handlers to catch these.  Consequently, the detail of the exception was not getting into the log; that is, the underlying cause was getting lost.  This PR was created to correct this.  Testing showed that the precipitating error resulted from S3 SDK resources was not being adequately cleaned up (specifically, during handling of HEAD requests).  This PR includes a fix to this problem as well.  

The underlying resource clean-up issue was coming up due to heavy access to the distribution service by a data.gov robot.  This is hard to replicate on the test system (in a timely way).  Instead, I did a hot-fix test on the production system itself.  After some 300 HEAD requests, the clean-up error did not re-occur.  Meanwhile, I am setting up a test harness deployable on oardev.