### PR TITLE
ODD-760:  Fix 500 response when requesting download URL missing a dataset id/file path

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -301,7 +301,11 @@ public class DatasetAccessController {
 
         String filepath = (String) request.getAttribute(
                                       HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-        filepath = filepath.substring("/ds/".length() + dsid.length() + 1);
+        filepath = filepath.substring("/ds/".length() + dsid.length());
+        if (filepath.startsWith("/")) filepath = filepath.substring(1);
+        
+        // If filepath now equals "", a FileNotFoundException will get thrown if dsid exists; 
+        // otherwise a ResourceNotFoundException will be thrown.
 
         String ver = null;
         if (filepath.startsWith("_v/")) {

--- a/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
@@ -236,6 +236,28 @@ public class DatasetAccessControllerTest {
     }
 
     @Test
+    public void testDownloadFileMissingDSID() throws JSONException {
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491.json",
+                                                      HttpMethod.GET, req, String.class);
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+        assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491.json\"," +
+                                 "status:404,message:\"Resource ID not found\",method:GET}",
+                                resp.getBody(), true);
+
+        req = new HttpEntity<String>(null, headers);
+        resp = websvc.exchange(getBaseURL() + "/ds/mds1491/", HttpMethod.GET, req, String.class);
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+        assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
+        JSONAssert.assertEquals("{requestURL:\"/od/ds/mds1491/\"," +
+                                "status:404,message:\"File not found in requested dataset\",method:GET}",
+                                resp.getBody(), true);
+    }
+
+    @Test
     public void testDownloadFileBadInp() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/goober/trial1.json",


### PR DESCRIPTION
This addresses issue ODD-760 ("Return 404 if single file/path does not exist") that points out that the distribution service is returning a 500 error if the (single-file) download URL is missing a dataset identifier or file path instead of a 404.  This fixes this bug.  

For example, the following URLs should now return 404:
```
   https://localhost/od/ds/data.json
   https://localhost/od/ds/ECBCC1C1301D2ED9E04306570681B10735
   https://localhost/od/ds/ECBCC1C1301D2ED9E04306570681B10735/
```

