### PR TITLE
ODD-778:  Support new ARK-ID pattern

### DIFF
--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:8-jdk-slim-stretch
 
+# a hack that gets around an installation problem with update-alternatives, openjdk-8-jdk-headless
+RUN mkdir -p /usr/share/man/man1
+
 RUN apt-get update && apt-get upgrade -y && apt-get install -y netcat-openbsd zip git less \
                                             gnupg python python-pip python-virtualenv \
                                             make gcc curl maven

--- a/src/main/java/gov/nist/oar/bags/preservation/BagUtils.java
+++ b/src/main/java/gov/nist/oar/bags/preservation/BagUtils.java
@@ -327,8 +327,8 @@ public class BagUtils {
         while (true) {
             // loop through possible matching version strings
             vernamere = (version.length() == 0)
-                           ? Pattern.compile("^(\\w+)\\.mbag")
-                           : Pattern.compile("^(\\w+)\\."+version+"\\.");
+                           ? Pattern.compile("^(\\w[\\w\\-]*)\\.mbag")
+                           : Pattern.compile("^(\\w[\\w\\-]*)\\."+version+"\\.");
             for (String name : bagnames) {
                 if (vernamere.matcher(name).find())
                     out.add(name);

--- a/src/main/java/gov/nist/oar/bags/preservation/BagUtils.java
+++ b/src/main/java/gov/nist/oar/bags/preservation/BagUtils.java
@@ -39,8 +39,8 @@ import java.io.UnsupportedEncodingException;
  */
 public class BagUtils {
 
-    static Pattern bagname1re = Pattern.compile("^(\\w+)\\.mbag(\\d+_\\d+)-(\\d+)(\\..*)?$");
-    static Pattern bagname2re = Pattern.compile("^(\\w+)\\.(\\d+(_\\d+)*)\\.mbag(\\d+_\\d+)-(\\d+)(\\..*)?$");
+    static Pattern bagname1re = Pattern.compile("^(\\w[\\w\\-]*)\\.mbag(\\d+_\\d+)-(\\d+)(\\..*)?$");
+    static Pattern bagname2re = Pattern.compile("^(\\w[\\w\\-]*)\\.(\\d+(_\\d+)*)\\.mbag(\\d+_\\d+)-(\\d+)(\\..*)?$");
     static Pattern dotdelim = Pattern.compile("\\.");
     static Pattern usdelim = Pattern.compile("_");
 

--- a/src/test/java/gov/nist/oar/bags/preservation/BagUtilsTest.java
+++ b/src/test/java/gov/nist/oar/bags/preservation/BagUtilsTest.java
@@ -285,6 +285,62 @@ public class BagUtilsTest {
 
         mtchd = BagUtils.selectVersion(names, "3.1");
         assertEquals(0, mtchd.size());
-    }    
+    }
+    
+    @Test
+    public void testSelectVersionDash() {
+        ArrayList<String> names = new ArrayList<String>(8);
+        names.add("go-ober.mbag0_2-0");
+        names.add("go-ober.0_1.mbag0_2-0");
+        names.add("go-ober.0_1.mbag0_2-1");
+        names.add("go-ober.2.mbag0_2-1");
+        names.add("go-ober.3_1_15.mbag0_2-1");
+        names.add("go-ober.3_1_15.mbag0_2-2");
+        names.add("go-ober.3_1_15.mbag0_4-3");
+        names.add("go-ober.4_0.mbag0_2-1");
+
+        List<String> mtchd = BagUtils.selectVersion(names, "0.1");
+        assertTrue("Failed to match a version: 0.1", mtchd.size() > 0);
+        assertEquals("go-ober.0_1.mbag0_2-0", mtchd.get(0));
+        assertEquals("go-ober.0_1.mbag0_2-1", mtchd.get(1));
+        assertEquals(2, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "0_1");
+        assertTrue("Failed to match a version: 0_1", mtchd.size() > 0);
+        assertEquals("go-ober.0_1.mbag0_2-0", mtchd.get(0));
+        assertEquals("go-ober.0_1.mbag0_2-1", mtchd.get(1));
+        assertEquals(2, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "0.1.0");
+        assertTrue("Failed to match a version: 0.1.0", mtchd.size() > 0);
+        assertEquals("go-ober.0_1.mbag0_2-0", mtchd.get(0));
+        assertEquals("go-ober.0_1.mbag0_2-1", mtchd.get(1));
+        assertEquals(2, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "2.0.0");
+        assertTrue("Failed to match a version: 2.0.0", mtchd.size() > 0);
+        assertEquals("go-ober.2.mbag0_2-1", mtchd.get(0));
+        assertEquals(1, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "0");
+        assertTrue("Failed to match a the unspecified version: (0)", mtchd.size() > 0);
+        assertEquals("go-ober.mbag0_2-0", mtchd.get(0));
+        assertEquals(1, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "1");
+        assertTrue("Failed to match a version: 1", mtchd.size() > 0);
+        assertEquals("go-ober.mbag0_2-0", mtchd.get(0));
+        assertEquals(1, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "3.1.15");
+        assertTrue("Failed to match a version: 3.1.15", mtchd.size() > 0);
+        assertEquals("go-ober.3_1_15.mbag0_2-1", mtchd.get(0));
+        assertEquals("go-ober.3_1_15.mbag0_2-2", mtchd.get(1));
+        assertEquals("go-ober.3_1_15.mbag0_4-3", mtchd.get(2));
+        assertEquals(3, mtchd.size());
+
+        mtchd = BagUtils.selectVersion(names, "3.1");
+        assertEquals("Matched a non-existent version", 0, mtchd.size());
+    }
 }
 

--- a/src/test/java/gov/nist/oar/bags/preservation/BagUtilsTest.java
+++ b/src/test/java/gov/nist/oar/bags/preservation/BagUtilsTest.java
@@ -48,6 +48,7 @@ public class BagUtilsTest {
         assertTrue(BagUtils.isLegalBagName("6376FC675D0E1D77E0531A5706812BC21886.02.mbag10_22-13.zip"));
         assertTrue(BagUtils.isLegalBagName("6376FC675D0E1D77E0531A5706812BC21886.67.mbag10_22-13.tar.gz"));
         assertTrue(BagUtils.isLegalBagName("6376FC675D0E1D77E0531A5706812BC21886.67_3_199.mbag10_22-13.tar.gz"));
+        assertTrue(BagUtils.isLegalBagName("pdr19-1886.67_3_199.mbag10_22-13.tar.gz"));
         
         assertFalse(BagUtils.isLegalBagName("go.ober.mbag10_22-13.tar.gz"));
         assertFalse(BagUtils.isLegalBagName("goober.mbag10.22-13.tar.gz"));
@@ -56,6 +57,7 @@ public class BagUtilsTest {
         //Test the names with bagversion
         assertFalse(BagUtils.isLegalBagName("go.ober.9.mbag10_22-13.tar.gz"));
         assertFalse(BagUtils.isLegalBagName("goober.10_34.mbag10.22-13.tar.gz"));
+        assertFalse(BagUtils.isLegalBagName("-pdr19-1886.67_3_199.mbag10_22-13.tar.gz"));
         
         
     }

--- a/src/test/java/gov/nist/oar/distrib/storage/FilesystemLongTermStorageTest.java
+++ b/src/test/java/gov/nist/oar/distrib/storage/FilesystemLongTermStorageTest.java
@@ -53,7 +53,8 @@ public class FilesystemLongTermStorageTest {
         // setup a little repo
         String[] bases = {
             "mds013u4g.1_0_0.mbag0_4-", "mds013u4g.1_0_1.mbag0_4-", "mds013u4g.1_1.mbag0_4-",
-            "mds088kd2.mbag0_3-", "mds088kd2.mbag0_3-", "mds088kd2.1_0_1.mbag0_4-"
+            "mds088kd2.mbag0_3-", "mds088kd2.mbag0_3-", "mds088kd2.1_0_1.mbag0_4-",
+            "mds2-1865.2_1.mbag0_4-"
         };
         Path f = null;
         int j = 0;
@@ -177,7 +178,7 @@ public class FilesystemLongTermStorageTest {
     } 
 
     @Test
-    public void testFileHeadbag() throws FileNotFoundException, DistributionException {
+    public void testFindHeadbag() throws FileNotFoundException, DistributionException {
         LongTermStorage fStorage = new FilesystemLongTermStorage(testdir.toString());
 
         assertEquals("mds088kd2.1_0_1.mbag0_4-17.7z", fStorage.findHeadBagFor("mds088kd2")); 
@@ -190,6 +191,7 @@ public class FilesystemLongTermStorageTest {
         assertEquals("mds088kd2.1_0_1.mbag0_4-17.7z", fStorage.findHeadBagFor("mds088kd2", "1.0.1")); 
         assertEquals("mds088kd2.mbag0_3-14.7z", fStorage.findHeadBagFor("mds088kd2", "0")); 
         assertEquals("mds088kd2.mbag0_3-14.7z", fStorage.findHeadBagFor("mds088kd2", "1")); 
+        assertEquals("mds2-1865.2_1.mbag0_4-20.7z", fStorage.findHeadBagFor("mds2-1865", "2.1")); 
 
         try {
             String bagname = fStorage.findHeadBagFor("mds013u4g9");

--- a/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DatasetAccessControllerTest.java
@@ -236,6 +236,17 @@ public class DatasetAccessControllerTest {
     }
 
     @Test
+    public void testDownloadFileViaARK() {
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/ark:/1212/mds1491/trial1.json",
+                                                      HttpMethod.GET, req, String.class);
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
+        assertEquals(69, resp.getBody().length());
+    }
+
+    @Test
     public void testDownloadFileMissingDSID() throws JSONException {
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
         ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/mds1491.json",
@@ -346,6 +357,28 @@ public class DatasetAccessControllerTest {
                                                       HttpMethod.HEAD, req, String.class);
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
+        assertNull(resp.getBody());
+    }
+
+    @Test
+    public void testDownloadFileInfoViaARK() {
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/ark:/8888/mds1491/trial1.json",
+                                                      HttpMethod.HEAD, req, String.class);
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
+        assertNull(resp.getBody());
+    }
+
+    @Test
+    public void testDownloadFileInfoViaBadARK() {
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/ark:/mds1491/goob/trial1.json",
+                                                      HttpMethod.HEAD, req, String.class);
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         assertTrue(resp.getHeaders().getFirst("Content-Type").startsWith("application/json"));
         assertNull(resp.getBody());
     }


### PR DESCRIPTION
This PR is part of a suite of changes related to [ODD-778](http://mml.nist.gov:8080/browse/ODD-778) which calls for supporting ARK-ID-based EDI IDs during the publishing process (see [oar-pdr PR#79](https://github.com/usnistgov/oar-pdr/pull/79)). MIDAS will begin setting the identifier property in new POD records to an identifier starting with `ark:/88484/mds2-` and the PDR will adopt this as its local NERDm identifier. The design requires changes for accessing bags and data files via the distribution service to enable support for the ID pattern.

This PR makes the following updates:
 *  The patterns used for recognizing and manipulating legal bag names has been updated to support the new identifier form.
 *  new request mappings were added to DatasetAccessController to allow for use of the full ARK ID string in access URLs