### PR TITLE
Bug fix: Add pagination to AWS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,17 +124,24 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+        <!--
+          -  This s3mock does not properly support pagination; using
+          -  com.adobe.testing.s3mock instead.  See s3mock subdir.
+          -
         <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>
             <version>0.2.5</version>
             <scope>test</scope>
         </dependency>
-        <!-- <dependency>
-    <groupId>org.json</groupId>
-    <artifactId>json</artifactId>
-    <version>20180813</version>
-</dependency> -->
+          -->
+        <!--
+        <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20180813</version>
+        </dependency>
+        -->
     </dependencies>
     <build>
         <finalName>oar-dist-service</finalName>

--- a/s3mock/runS3MockServer.sh
+++ b/s3mock/runS3MockServer.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo CWD=`pwd`
+echo java -XX:+UseContainerSupport -Xmx128m -Djava.security.egd=file:/dev/./urandom -jar s3mock-2.1.19.jar
+exec java -XX:+UseContainerSupport -Xmx128m -Djava.security.egd=file:/dev/./urandom -jar s3mock-2.1.19.jar

--- a/src/test/java/gov/nist/oar/bags/preservation/BagUtilsTest.java
+++ b/src/test/java/gov/nist/oar/bags/preservation/BagUtilsTest.java
@@ -77,6 +77,55 @@ public class BagUtilsTest {
       need.set(4, "tar.gz");
       assertEquals(need, BagUtils.parseBagName("6376FC675D0E1D77E0531A5706812BC21886.02.mbag10_22-13.tar.gz"));
     }
+
+    @Test
+    public void testSequenceNumberIn() {
+        assertEquals(0, BagUtils.sequenceNumberIn("goober.mbag0_3-0.zip"));
+        assertEquals(0, BagUtils.sequenceNumberIn("goober.mbag0_3-0"));
+        assertEquals(2, BagUtils.sequenceNumberIn("goober.mbag0_3-2"));
+        assertEquals(2, BagUtils.sequenceNumberIn("goober.1_0_3.mbag0_4-2"));
+        assertEquals(223, BagUtils.sequenceNumberIn("goober.mbag10_2-223"));
+        assertEquals(21, BagUtils.sequenceNumberIn("goober.1_81_413.mbag10_223-21.tar.gz"));
+        assertEquals(-1, BagUtils.sequenceNumberIn("6376FC675D0E1D77E0531A5706812BC21886"));
+        assertEquals(-1, BagUtils.sequenceNumberIn("goober.mbag10_2-test"));
+    }
+
+    @Test
+    public void test_make_nameverre() {
+        String base = "^(\\w[\\w\\-]*)\\.";
+        assertEquals(base+"1(_0)*\\.", BagUtils._make_nameverre("1.0.0.0").pattern());
+        assertEquals(base+"1(_0)*\\.", BagUtils._make_nameverre("1.0.0").pattern());
+        assertEquals(base+"1(_0)*\\.", BagUtils._make_nameverre("1.0").pattern());
+        assertEquals(base+"1(_0)*\\.", BagUtils._make_nameverre("1").pattern());
+
+        assertEquals(base+"2_1(_0)*\\.", BagUtils._make_nameverre("2.1.0").pattern());
+        assertEquals(base+"2_1(_0)*\\.", BagUtils._make_nameverre("2.1").pattern());
+
+        assertEquals(base+"1_3_4(_0)*\\.", BagUtils._make_nameverre("1.3.4").pattern());
+        assertEquals(base+"1_0_4(_0)*\\.", BagUtils._make_nameverre("1.0.4").pattern());
+        
+        assertEquals(base+"0(_0)*\\.", BagUtils._make_nameverre("0.0.0.0").pattern());
+    }
+    
+    @Test
+    public void testMatchesVersion() {
+        assertTrue(BagUtils.matchesVersion("goober.1_0_0.mbag0_3-0.zip", "1.0.0"));
+        assertTrue(BagUtils.matchesVersion("goober.1_0_0.mbag0_3-0", "1.0_0"));
+        assertTrue(BagUtils.matchesVersion("goober.1_0.mbag0_3-0", "1_0_0"));
+        assertTrue(BagUtils.matchesVersion("goober.1_0_0_0.mbag0_3-0", "1.0"));
+        assertTrue(! BagUtils.matchesVersion("goober.2_0.mbag0_3-0", "1.0.0"));
+        assertTrue(! BagUtils.matchesVersion("goober.1_0_0.mbag0_3-0", "1.0.2"));
+        assertTrue(! BagUtils.matchesVersion("goober.1_0_0.mbag0_3-0", "2.0.2"));
+        
+        assertTrue(BagUtils.matchesVersion("goober.mbag0_2-0", ""));
+        assertTrue(BagUtils.matchesVersion("goober.mbag0_2-2", "1"));
+        assertTrue(BagUtils.matchesVersion("goober.1.mbag0_2-2", "1"));
+        assertTrue(BagUtils.matchesVersion("goober.mbag0_2-2", "0"));
+        assertTrue(BagUtils.matchesVersion("goober.mbag0_2-3", "1.0.0"));
+        
+        assertTrue(BagUtils.matchesVersion("goober.1_81_413.mbag10_223-21.tar.gz", "1.81.413.0"));
+        assertTrue(! BagUtils.matchesVersion("6376FC675D0E1D77E0531A5706812BC21886", "1.0"));
+    }
     
     @Test
     public void testParseBagName() throws ParseException {

--- a/src/test/java/gov/nist/oar/bags/preservation/ZipBagUtilsTest.java
+++ b/src/test/java/gov/nist/oar/bags/preservation/ZipBagUtilsTest.java
@@ -213,15 +213,4 @@ public class ZipBagUtilsTest {
             assertEquals(5, comps.length());
         }
     }
-
-    @Test
-    public void testgetResourceMetadata2() throws IOException, JSONException {
-        try (InputStream zis = getClass().getResourceAsStream("/mds2-2195.1_2_0.mbag0_4-718.zip")) {
-            JSONObject res = ZipBagUtils.getResourceMetadata("0.4", zis, "mds2-2195.1_2_0.mbag0_4-718");
-            assertNotNull(res);
-            assertEquals("ark:/88434/mds2-2195", res.optString("@id"));
-            JSONArray comps = res.getJSONArray("components");
-            assertEquals(2013, comps.length());
-        }
-    }
 }

--- a/src/test/java/gov/nist/oar/bags/preservation/ZipBagUtilsTest.java
+++ b/src/test/java/gov/nist/oar/bags/preservation/ZipBagUtilsTest.java
@@ -213,4 +213,15 @@ public class ZipBagUtilsTest {
             assertEquals(5, comps.length());
         }
     }
+
+    @Test
+    public void testgetResourceMetadata2() throws IOException, JSONException {
+        try (InputStream zis = getClass().getResourceAsStream("/mds2-2195.1_2_0.mbag0_4-718.zip")) {
+            JSONObject res = ZipBagUtils.getResourceMetadata("0.4", zis, "mds2-2195.1_2_0.mbag0_4-718");
+            assertNotNull(res);
+            assertEquals("ark:/88434/mds2-2195", res.optString("@id"));
+            JSONArray comps = res.getJSONArray("components");
+            assertEquals(2013, comps.length());
+        }
+    }
 }

--- a/src/test/java/gov/nist/oar/distrib/storage/AWSS3LongTermStorageTest.java
+++ b/src/test/java/gov/nist/oar/distrib/storage/AWSS3LongTermStorageTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
@@ -32,12 +33,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
 
 import gov.nist.oar.distrib.Checksum;
 import gov.nist.oar.distrib.LongTermStorage;
@@ -45,7 +48,8 @@ import gov.nist.oar.distrib.DistributionException;
 import gov.nist.oar.distrib.ResourceNotFoundException;
 import gov.nist.oar.bags.preservation.BagUtils;
 
-import io.findify.s3mock.S3Mock;
+// import com.adobe.testing.s3mock.S3MockApplication;
+// import gov.nist.oar.RequireWebSite;
 
 /**
  * This is test class is used to connect to long term storage on AWS S3
@@ -54,33 +58,44 @@ import io.findify.s3mock.S3Mock;
  * @author Deoyani Nandrekar-Heinis
  */
 public class AWSS3LongTermStorageTest {
-  
-    private static Logger logger = LoggerFactory.getLogger(AWSS3LongTermStorageTest.class);
 
-    static int port = 9001;
+    // static S3MockApplication mockServer = null;
+    @ClassRule
+    public static S3MockTestRule siterule = new S3MockTestRule();
+    
+    static AmazonS3 s3client = null;
+  
+    // private static Logger logger = LoggerFactory.getLogger(AWSS3LongTermStorageTest.class);
+
+    // static int port = 9001;
     static final String bucket = "oar-lts-test";
     static String hash = "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9";
-    static S3Mock api = new S3Mock.Builder().withPort(port).withInMemoryBackend().build();
-    static AmazonS3 s3client = null;
     AWSS3LongTermStorage s3Storage = null;
   
     @BeforeClass
     public static void setUpClass() throws IOException {
-        String endpoint = "http://localhost:"+Integer.toString(port);
-        api.start();
-        s3client = AmazonS3ClientBuilder.standard()
-                                        .withPathStyleAccessEnabled(true)  
-                                        .withEndpointConfiguration(
-                                                 new AwsClientBuilder.EndpointConfiguration(endpoint,
-                                                                                            "us-east-1"))
-                                        .withCredentials(new AWSStaticCredentialsProvider(
-                                                                      new AnonymousAWSCredentials()))
-                                        .build();
+        // mockServer = S3MockApplication.start();  // http: port=9090
+        s3client = createS3Client();
         
         if (s3client.doesBucketExistV2(bucket))
             destroyBucket();
         s3client.createBucket(bucket);
         populateBucket();
+    }
+
+    public static AmazonS3 createS3Client() {
+        // import credentials from the EC2 machine we are running on
+        final BasicAWSCredentials credentials = new BasicAWSCredentials("foo", "bar");
+        final String endpoint = "http://localhost:9090/";
+        final String region = "us-east-1";
+        EndpointConfiguration epconfig = new EndpointConfiguration(endpoint, region);
+
+        AmazonS3 client = AmazonS3Client.builder()
+                                        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                                        .withEndpointConfiguration(epconfig)
+                                        .enablePathStyleAccess()
+                                        .build();
+        return client;
     }
 
     @Before
@@ -96,7 +111,7 @@ public class AWSS3LongTermStorageTest {
     @AfterClass
     public static void tearDownClass() {
         destroyBucket();
-        api.shutdown();
+        // mockServer.stop();
     }
 
     public static void destroyBucket() {
@@ -180,6 +195,23 @@ public class AWSS3LongTermStorageTest {
  
         assertEquals(filenames, found);
     }
+    
+    @Test
+    public void testFindBagsForByPage() throws DistributionException, FileNotFoundException {
+        s3Storage.setPageSize(4);
+        List<String> filenames = new ArrayList<String>();
+        filenames.add("mds013u4g.1_0_0.mbag0_4-0.zip");
+        filenames.add("mds013u4g.1_0_0.mbag0_4-1.zip");
+        filenames.add("mds013u4g.1_0_0.mbag0_4-2.7z");
+        filenames.add("mds013u4g.1_0_1.mbag0_4-3.zip");
+        filenames.add("mds013u4g.1_0_1.mbag0_4-4.zip");
+        filenames.add("mds013u4g.1_0_1.mbag0_4-5.7z");
+        filenames.add("mds013u4g.1_1.mbag0_4-6.zip");
+        filenames.add("mds013u4g.1_1.mbag0_4-7.zip");
+        filenames.add("mds013u4g.1_1.mbag0_4-8.7z");
+ 
+        assertEquals(filenames, s3Storage.findBagsFor("mds013u4g"));
+    }
 
     @Test
     public void testFileChecksum() throws FileNotFoundException, DistributionException  {
@@ -225,6 +257,27 @@ public class AWSS3LongTermStorageTest {
 
     @Test
     public void testFileHeadbag() throws FileNotFoundException, DistributionException {
+        assertEquals("mds088kd2.1_0_1.mbag0_4-17.7z", s3Storage.findHeadBagFor("mds088kd2")); 
+        assertEquals("mds013u4g.1_1.mbag0_4-8.7z",    s3Storage.findHeadBagFor("mds013u4g"));
+
+        assertEquals("mds013u4g.1_1.mbag0_4-8.7z",    s3Storage.findHeadBagFor("mds013u4g", "1.1"));
+        assertEquals("mds013u4g.1_0_1.mbag0_4-5.7z",  s3Storage.findHeadBagFor("mds013u4g", "1.0.1"));
+        assertEquals("mds013u4g.1_0_0.mbag0_4-2.7z",  s3Storage.findHeadBagFor("mds013u4g", "1.0.0"));
+
+        assertEquals("mds088kd2.1_0_1.mbag0_4-17.7z", s3Storage.findHeadBagFor("mds088kd2", "1.0.1")); 
+        assertEquals("mds088kd2.mbag0_3-14.7z", s3Storage.findHeadBagFor("mds088kd2", "0")); 
+        assertEquals("mds088kd2.mbag0_3-14.7z", s3Storage.findHeadBagFor("mds088kd2", "1")); 
+
+        try {
+            String bagname = s3Storage.findHeadBagFor("mds013u4g9");
+            fail("Failed to raise ResourceNotFoundException; returned "+bagname.toString());
+        } catch (ResourceNotFoundException ex) { }
+
+    }
+
+    @Test
+    public void testFindHeadbagByPage() throws FileNotFoundException, DistributionException {
+        s3Storage.setPageSize(2);
         assertEquals("mds088kd2.1_0_1.mbag0_4-17.7z", s3Storage.findHeadBagFor("mds088kd2")); 
         assertEquals("mds013u4g.1_1.mbag0_4-8.7z",    s3Storage.findHeadBagFor("mds013u4g"));
 

--- a/src/test/java/gov/nist/oar/distrib/storage/S3MockTestRule.java
+++ b/src/test/java/gov/nist/oar/distrib/storage/S3MockTestRule.java
@@ -1,0 +1,123 @@
+/**
+ * This software was developed at the National Institute of Standards and Technology by employees of
+ * the Federal Government in the course of their official duties. Pursuant to title 17 Section 105
+ * of the United States Code this software is not subject to copyright protection and is in the
+ * public domain. This is an experimental system. NIST assumes no responsibility whatsoever for its
+ * use by other parties, and makes no guarantees, expressed or implied, about its quality,
+ * reliability, or any other characteristic. We would appreciate acknowledgement if the software is
+ * used. This software can be redistributed and/or modified freely provided that any derivative
+ * works bear some notice that they are derived from it, and any modified versions bear some notice
+ * that they have been modified.
+ */
+package gov.nist.oar.distrib.storage;
+
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+import org.junit.runner.Description;
+import org.junit.AssumptionViolatedException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.net.MalformedURLException;
+import java.net.HttpURLConnection;
+import java.io.IOException;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.lang.ProcessBuilder.Redirect;
+
+/**
+ * a JUnit ClassRule that starts a S3Mock server in a separate process for testing purposes
+ */
+public class S3MockTestRule implements TestRule {
+
+    static final String _testurl = "http://localhost:9090/";
+    private File serverdir = null;
+    private File script = null;
+    private Process server = null;
+    private Logger log = LoggerFactory.getLogger(getClass());
+
+    public S3MockTestRule() {
+        File cwd = new File(System.getProperty("user.dir", "."));
+        serverdir = new File(cwd, "s3mock");
+        script = new File(serverdir, "runS3MockServer.sh");
+    }
+
+    public void startServer() throws IOException {
+        String scrp = script.getAbsolutePath();
+        log.info("Starting server in dir="+serverdir.toString());
+        log.info("  See server log in s3mock-server.log");
+        server = new ProcessBuilder(scrp).directory(serverdir)
+                                         .redirectErrorStream(true)
+                                         .redirectOutput(Redirect.to(new File("s3mock-server.log")))
+                                         .start();
+        if (! server.isAlive())
+            throw new IllegalStateException("Server exited prematurely; status="+
+                                            Integer.toString(server.exitValue()));
+    }
+
+    public void stopServer() {
+        log.info("Shutting down S3Mock server");
+        server.destroy();
+    }
+
+    public boolean checkAvailable() throws MalformedURLException {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) (new URL(_testurl)).openConnection();
+            conn.setInstanceFollowRedirects(true);
+            conn.setConnectTimeout(1000);
+            conn.setReadTimeout(1000);
+            int status = conn.getResponseCode();
+            conn.getContent();
+
+            if (status >= 200 && status < 300)
+                return true;
+            return false;
+        }
+        catch (IOException ex) {
+            log.warn("S3Mock Service is not up yet ("+ex.getMessage()+")");
+            return false;
+        }
+        finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
+    public boolean waitForServer(long timeoutms) throws InterruptedException, MalformedURLException {
+        long starttime = System.currentTimeMillis();
+        
+        while (System.currentTimeMillis() - starttime < timeoutms) {
+            if (! server.isAlive())
+                throw new IllegalStateException("Server exited prematurely; status="+
+                                                Integer.toString(server.exitValue()));
+            if (checkAvailable())
+                return true;
+            Thread.sleep(1000);
+        }
+
+        return false;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description desc) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                if (! script.exists())
+                    throw new AssumptionViolatedException(script.toString() +
+                                                   ": S3Mock server script not found (skipping AWS tests)");
+                startServer();
+                try {
+                    if (! waitForServer(10000))
+                        throw new IllegalStateException("S3Mock server not responding after 10s.");
+                    base.evaluate();
+                }
+                finally {
+                    stopServer();
+                }
+            }
+        };
+    }
+}    


### PR DESCRIPTION
With the advent of a dataset packed into an excess of 1000 different bags, the lack of support for AWS query response pagination caused the service to miss identify the dataset's headbag.  In particular, a query to the AWS S3 bucket for a listing of bags matching the dataset's identifier results in more than 1000 files and, thus, exceeded AWS 1000 file default limit; to get the full list one much resubmit the query with a continuation token.  This PR addresses this shortcoming via the `AWSS3LongTermStorage` implementation.  

In the course of the development for this PR, I found that our [S3Mock library (from io.findify)](https://github.com/findify/s3mock) did not properly support continuation tokens, making it impossible to unit-test these changes.  I had to switch to the [S3Mock implementation from Adobe](https://github.com/adobe/s3mock).  Unfortunately, this latter library runs its mock service using spring-boot which interferes with our spring-boot implementation within the Java/Maven unit-testing environment (a common problem).   To get around this, the mock service is launched as separate Java process (see the new [s3mock subdirectory](https://github.com/usnistgov/oar-dist-service/tree/76a56906144949ace3c1c5a8280a492e25edb3d3/s3mock) and the new [S3MockTestRule](https://github.com/usnistgov/oar-dist-service/blob/76a56906144949ace3c1c5a8280a492e25edb3d3/src/test/java/gov/nist/oar/distrib/storage/S3MockTestRule.java)).

Note also that to assist in the updated `AWSS3LongTermStorage` implementation, new functionality was added to `BagUtils`.