### PR TITLE
Bundle Size and error messages.

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/datapackage/ValidationHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/datapackage/ValidationHelper.java
@@ -93,6 +93,10 @@ public class ValidationHelper {
 	    long length = conn.getContentLengthLong();
 	    allowedRedirects--;
 	    String location = conn.getHeaderField("Location");
+	    
+	    if ((responseCode >= 300 && responseCode < 400) && allowedRedirects == 0) {
+	    	return new URLStatusLocation(responseCode, location, url, 0, true);  	
+	    }
 
 	    if ((responseCode >= 300 && responseCode < 400) && allowedRedirects > 0)
 		return checkURLStatusLocationSize(location, allowedRedirects);

--- a/src/test/java/gov/nist/oar/distrib/web/BundleDownloadPlanControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/BundleDownloadPlanControllerTest.java
@@ -175,7 +175,7 @@ public class BundleDownloadPlanControllerTest {
 	String respBody = newResponse.getBody();
 	BundleDownloadPlan bundleResponse = mapperResults.readValue(respBody, BundleDownloadPlan.class);
 	System.out.println(" Response :"+respBody+ "\n Bundle Response"+bundleResponse.getStatus());
-	String message = "No Files added in the Bundle, there are problems accessing URLs.".trim();
+	String message = "None of the selected files are available due to failures accessing files from their remote server.".trim();
 	assertEquals("Error", bundleResponse.getStatus());
 	assertEquals("_bundle", bundleResponse.getPostEachTo());
 	assertEquals(message,bundleResponse.getMessages()[0].trim());
@@ -214,7 +214,7 @@ public class BundleDownloadPlanControllerTest {
 	String responsetest = response.getBody();
 	BundleDownloadPlan testResponse = mapperResults.readValue(responsetest, BundleDownloadPlan.class);
 //	System.out.println("Response :"+responsetest+"\n"+testResponse.getMessages()[0]);
-	String message = "Some URLs have problem accessing contents.".trim();
+	String message = "Some of the selected data files were not downloaded due to failures accessing files from their remote server.".trim();
 	assertEquals("warnings", testResponse.getStatus());
 	assertEquals("_bundle", testResponse.getPostEachTo());
 	assertEquals(message,testResponse.getMessages()[0].trim());


### PR DESCRIPTION
This branch addresses issues as below
1. Bundle Size was not getting calculated properly if there are redirect URLs present. It is fixed in this branch.
2. Error messages are updated as per the discussions so can be displayed on UI.