### PR TITLE
Leverage auto-computed hashes by AWS for faster integrity checking

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/cachemgr/BasicCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/BasicCacheManager.java
@@ -110,6 +110,9 @@ public abstract class BasicCacheManager extends CacheManager {
             return false;
 
         try {
+            // get rid of any previously existing copies
+            theCache.uncache(id);
+            
             long sz = restorer.getSizeOf(id);       // may throw ObjectNotFoundException
             if (prefs < 1)
                 prefs = getDefaultPreferencesFor(id, sz);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/CacheObject.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/CacheObject.java
@@ -177,6 +177,19 @@ public class CacheObject {
     }
 
     /**
+     * return the time in Epoch milliseconds of the last modification of the object within its
+     * cache volume or -1 if unknown.  This time is normally the time that the object was saved 
+     * to the volume.
+     */
+    public long getLastModified() {
+        try {
+            return getMetadatumLong("modified", -1L);
+        } catch (JSONException ex) {
+            return -1L;
+        }
+    }
+
+    /**
      * return the value of a metadatum as an integer.  
      * @param name   the name of the metadatum
      * @param defval the value to return if a value is not set for name

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/CacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/CacheVolume.java
@@ -62,9 +62,12 @@ public interface CacheVolume {
      *                 to save.  (The caller is responsible for closing the stream
      *                 after this method returns.)
      * @param name   the name to assign to the object within the storage.  
-     * @param md     the metadata to be associated with that object (can be null).  Note 
-     *                 some implementations ({@link gov.nist.oar.distrib.cachemgr.storage.AWSS3CacheVolume}) 
-     *                 require that this include the "size" property.  
+     * @param md     the metadata to be associated with that object (can be null).  This 
+     *                 object may be updated with additional metadata (such as the object's
+     *                 modification time which would effectively be the same as the 
+     *                 creation time within the volume).  Note that some implementations 
+     *                 ({@link gov.nist.oar.distrib.cachemgr.storage.AWSS3CacheVolume}) 
+     *                 require that the input metadata include the "size" property.  
      * @throws StorageVolumeException  if the method fails to save the object correctly.
      * @throws JSONException   if a failure occurs while extracting values from the metadata
      */

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/inventory/ChecksumCheck.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/inventory/ChecksumCheck.java
@@ -27,13 +27,72 @@ import gov.nist.oar.distrib.ObjectNotFoundException;
 /**
  * a CacheObjectCheck that will calculate the checksum of an object to ensure it matches the value
  * stored in the object's metadata. 
+ *
+ * This check supports two construction-time switches which can improve the performance of the test.
+ * The first set via the <code>checkLastModified</code> argument (whose value is returned by 
+ * {@link #requireUnmodifiedByDate}) will require that the dates of the last modification match between 
+ * the given {@link gov.nist.oar.distrib.CacheObject} and the one stored in its volume.  This is based 
+ * on the assumption the object's metadata never changes (out-of-band) once it is place in the volume.  
+ * When enabled, this check is done before any actual checksum calculation and comparison to ensure a 
+ * fast fail. 
+ * 
+ * The second switch is set via the <code>useVolumeChecksum</code> argument (whose value is returned by
+ * {@link #canUseVolumeChecksum}).  If True, this check will attempt to use a volume-provided checksum 
+ * as the file's current checksum in lieu of calculating it from the object's byte stream.  Some volumes
+ * (namely an {@link gov.nist.oar.distrib.storage.AWSS3CacheVolume} with its "contentMD5" and "etag" 
+ * attributes) calculates and stores this value automatically.  If such a checksum is available, it will 
+ * be stored in the {@link gov.nist.oar.distrib.CacheObject} metadatum, "volumeChecksum", with a format 
+ * "LABEL HASH", where "LABEL" is the name of the checksum algorithm, and "HASH" is the checksum's hash 
+ * value.  If this volume-provided hash is available, a checksum is calculated as normal. 
  */
 public class ChecksumCheck implements CacheObjectCheck {
+
+    boolean _useVolChkSum = false;
+    boolean _checkMod = false;
 
     /**
      * create a <code>CacheObjectCheck</code> that can run checksum checks
      */
-    public ChecksumCheck() { }
+    public ChecksumCheck() { this(false, false); }
+
+    /**
+     * create a <code>CacheObjectCheck</code> that can run checksum checks
+     * @param checkLastModified       Require that the last modified date has not changed since the object
+     *                                was placed in the cache.  This check is done prior to the checksum
+     *                                calculation for a fast fail.
+     */
+    public ChecksumCheck(boolean checkLastModified) { this(checkLastModified, false); }
+
+    /**
+     * create a <code>CacheObjectCheck</code> that can run checksum checks
+     * @param checkLastModified       Require that the last modified date has not changed since the object
+     *                                was placed in the cache.  This check is done prior to the checksum
+     *                                calculation for a fast fail.
+     * @param leverageVolumeChecksum  if true and the volume supports a remotely stored checksum, this 
+     *                                this checksum will be used lieu of recalculating it from the object's 
+     *                                byte stream.  Enabling this, of course, will result in a much faster 
+     *                                check; however, one must be confident that it is not possible to 
+     *                                update the object without updating the volume-provided checksum.  
+     *                                It is recommended that <code>checkLastModified</code> be set to true
+     *                                if the volume checksum algorithm is less robust than that used by 
+     *                                the repository.
+     */
+    public ChecksumCheck(boolean checkLastModified, boolean useVolumeChecksum) {
+        _useVolChkSum = useVolumeChecksum;
+        _checkMod = checkLastModified;
+    }
+
+    /**
+     * return True if this ChecksumCheck allows for leveraging a Volume-provided checksum to take as the
+     * object's current checksum, in lieu of recalculating it from the object's byte stream.  If the volume
+     * does not provide such a checksum, it will get recalculated.  
+     */
+    public boolean canUseVolumeChecksum() { return _useVolChkSum; }
+
+    /**
+     * return True if the ChecksumCheck will require that the modification times match
+     */
+    public boolean requireUnmodifiedByDate() { return _checkMod; }
 
     /**
      * run the checksum check on an object
@@ -51,11 +110,32 @@ public class ChecksumCheck implements CacheObjectCheck {
         throws IntegrityException, StorageVolumeException, CacheManagementException
     {
         // First, check the sizes for expediency
-        long vsz = co.volume.get(co.name).getSize();
+        CacheObject vco = co.volume.get(co.name);
+        long vsz = vco.getSize();
         long sz = co.getSize();
         if (vsz >= 0 && sz >= 0 && vsz != sz)
-            throw new ChecksumMismatchException(co, null, vsz);
+            throw new ChecksumMismatchException(co, "size "+Long.toString(vsz), vsz);
 
+        // If required, we make sure the modification date has not changed
+        if (requireUnmodifiedByDate())
+            _checkLastModified(vco, co);
+
+        // If allowed and available, try using the volume-calculated hash
+        if (canUseVolumeChecksum() &&
+            co.hasMetadatum("volumeChecksum") && vco.hasMetadatum("volumeChecksum"))
+        {
+            if (! requireUnmodifiedByDate())
+                // force last modified check
+                _checkLastModified(vco, co);
+
+            if (! vco.getMetadatumString("volumeChecksum", "-")
+                     .equals(co.getMetadatumString("volumeChecksum", "")))
+                throw new ChecksumMismatchException(co, vco.getMetadatumString("volumeChecksum", "-"), vsz);
+
+            // we're happy
+            return;
+        }
+        
         String alg = co.getMetadatumString("checksumAlgorithm", null);
         if (alg == null)
             throw new CacheManagementException("Cache object is missing 'checksumAlgorithm' metadatum");
@@ -78,5 +158,14 @@ public class ChecksumCheck implements CacheObjectCheck {
         else {
             throw new CacheManagementException("Unsupported checksum algorithm: "+alg);
         }
+    }
+
+    private void _checkLastModified(CacheObject fromVol, CacheObject fromChkr)
+        throws ChecksumMismatchException
+    {
+        long vmod = fromVol.getLastModified();
+        long mod = fromChkr.getLastModified();
+        if (mod > 0L && vmod != mod) 
+            throw new ChecksumMismatchException(fromChkr, "modified "+Long.toString(vmod), fromVol.getSize());
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
@@ -881,14 +881,24 @@ public class PDRCacheManager extends BasicCacheManager implements PDRConstants, 
                     catch (CacheManagementException ex) {
                         log.error(ex.getMessage());
                     }
+                    catch (RuntimeException ex) {
+                        log.error("Unexpected caching error: "+ex.getMessage()+" (moving on)");
+                    }
                 }
             }
             catch (InterruptedException ex) {
                 log.info("Interruption of caching thread requested; exiting.");
             }
+            catch (RuntimeException ex) {
+                log.error("Unexpected caching error: "+ex.getMessage());
+            }
             finally {
                 try {
                     cath = cloneMe();
+                    if (_queue.peek() != null) {
+                        log.warn("Resuming cache queue processing");
+                        cath.start();
+                    }
                 } catch (IOException ex) {
                     log.error("Failed to refresh caching thread: queue persistence error: "+ex.getMessage());
                 }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
@@ -620,7 +620,7 @@ public class PDRCacheManager extends BasicCacheManager implements PDRConstants, 
         datamon.selectCorruptedObjects(cached, deleted, true);
         if (recache) {
             for (CacheObject co : deleted)
-                cache(co.id);
+                cache(co.id, recache);
         }
         return deleted;
     }
@@ -851,7 +851,7 @@ public class PDRCacheManager extends BasicCacheManager implements PDRConstants, 
                     cacheDataset(parts[0], parts[2], recache);
                 else if (recache || ! isCached(nextid))
                     // data file identifier
-                    cache(nextid);
+                    cache(nextid, true);
             }
             catch (ResourceNotFoundException ex) {
                 throw new CacheManagementException("Unable to cache "+nextid+": resource not found", ex);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
@@ -305,6 +305,8 @@ public class AWSS3CacheVolume implements CacheVolume {
                 long mod = co.getLastModified();
                 if (mod > 0L)
                     md.put("modified", mod);
+                if (co.hasMetadatum("volumeChecksum"))
+                    md.put("volumeChecksum", co.getMetadatumString("volumeChecksum", " "));
             }
             catch (ObjectNotFoundException ex) {
                 throw new StorageStateException("Upload apparently failed: "+ex.getMessage(), ex);
@@ -393,6 +395,7 @@ public class AWSS3CacheVolume implements CacheVolume {
         md.put("size", omd.getContentLength());
         md.put("contentType", omd.getContentType());
         md.put("modified", omd.getLastModified().getTime());
+        md.put("volumeChecksum", "etag " + omd.getETag());
 
         return new CacheObject(name, md, this);
     }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
@@ -298,6 +298,21 @@ public class AWSS3CacheVolume implements CacheVolume {
             }
             throw new StorageVolumeException("AWS client error: "+ex.getMessage()+"; object status unclear");
         }
+
+        if (md != null) {
+            try {
+                CacheObject co = get(name);
+                long mod = co.getLastModified();
+                if (mod > 0L)
+                    md.put("modified", mod);
+            }
+            catch (ObjectNotFoundException ex) {
+                throw new StorageStateException("Upload apparently failed: "+ex.getMessage(), ex);
+            }
+            catch (StorageVolumeException ex) {
+                throw new StorageStateException("Uploaded object status unclear: "+ex.getMessage(), ex);
+            }
+        }
     }
     
     /**
@@ -377,6 +392,7 @@ public class AWSS3CacheVolume implements CacheVolume {
         JSONObject md = new JSONObject();
         md.put("size", omd.getContentLength());
         md.put("contentType", omd.getContentType());
+        md.put("modified", omd.getLastModified().getTime());
 
         return new CacheObject(name, md, this);
     }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
@@ -272,7 +272,7 @@ public class FilesystemCacheVolume implements CacheVolume {
     /*
      * return the modification time on a file in epoch milliseconds
      */
-    public static getLastModifiedTimeOf(File f) throws IOException {
+    public static long getLastModifiedTimeOf(File f) throws IOException {
         Instant mod = Files.getLastModifiedTime(f.toPath()).toInstant();
         return mod.getEpochSecond() * 1000 + Math.round(mod.getNano()/1000000.0);
     }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
@@ -272,7 +272,7 @@ public class FilesystemCacheVolume implements CacheVolume {
     /*
      * return the modification time on a file in epoch milliseconds
      */
-    private long getLastModifiedTimeOf(File f) throws IOException {
+    public static getLastModifiedTimeOf(File f) throws IOException {
         Instant mod = Files.getLastModifiedTime(f.toPath()).toInstant();
         return mod.getEpochSecond() * 1000 + Math.round(mod.getNano()/1000000.0);
     }

--- a/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
@@ -467,7 +467,7 @@ public class NISTCacheManagerConfig {
             throw new ConfigurationException(rootdir+": Not an existing directory");
 
         List<CacheObjectCheck> checks = new ArrayList<CacheObjectCheck>();
-        checks.add(new ChecksumCheck());
+        checks.add(new ChecksumCheck(false, true));
         PDRCacheManager out = new PDRCacheManager(cache, rstr, checks, getCheckDutyCycle()*1000, 
                                                   getCheckGracePeriod()*1000, -1, rootdir, logger);
         if (getMonitorAutoStart()) {

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/CacheObjectTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/CacheObjectTest.java
@@ -63,14 +63,17 @@ public class CacheObjectTest {
         job.put("checksum", "s2h56a256");
         job.put("checksumAlgorithm", "sha256");
         job.put("refcount", 3);
+        job.put("modified", 1648461824000L);
 
         CacheObject co = new CacheObject("hank", job, (String)null);
 
         assertEquals(co.name, "hank");
         assertNull(co.volume);
         assertEquals(co.getSize(), 31L);
+        assertEquals(co.getLastModified(), 1648461824000L);
         assertEquals(co.getMetadatumLong("size", -1L), 31L);
         assertEquals(co.getMetadatumString("checksum", null), "s2h56a256");
         assertEquals(co.getMetadatumInt("refcount", -1), 3);
+        assertEquals(co.getMetadatumLong("modified", -1L), 1648461824000L);
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/inventory/ChecksumCheckTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/inventory/ChecksumCheckTest.java
@@ -61,7 +61,9 @@ public class ChecksumCheckTest {
 
     CacheObject makeobj(FilesystemCacheVolume v, String name, String contents) throws IOException {
         File out = _makefile(new File(v.getRootDir(), name), contents);
-        return new CacheObject(name, v);
+        JSONObject md = new JSONObject();
+        md.put("modified", out.lastModified());
+        return new CacheObject(name, md, v);
     }
 
     @Before
@@ -83,6 +85,7 @@ public class ChecksumCheckTest {
         md.put("size", 12L);
         md.put("checksum", hash);
         md.put("checksumAlgorithm", "sha256");
+        md.put("modified", co.getMetadatumLong("modified", -1L));
         co = new CacheObject(co.name, md, vol);
 
         chk.check(co);
@@ -101,9 +104,9 @@ public class ChecksumCheckTest {
         co = new CacheObject(co.name, md, vol);
         try {
             chk.check(co);
-            fail("Failed to detect different checksum");
+            fail("Failed to detect different size");
         } catch (ChecksumMismatchException ex) {
-            assertNull(ex.calculatedHash);
+            assertEquals("size 12", ex.calculatedHash);
             assertEquals(12L, ex.size);
         }
 
@@ -119,5 +122,102 @@ public class ChecksumCheckTest {
             chk.check(co);
             fail("Failed to report missing cache object");
         } catch (ObjectNotFoundException ex) {  }
+    }        
+
+    @Test
+    public void testModifiedCheck() throws IOException, CacheManagementException, StorageVolumeException {
+        CacheObject co = makeobj(vol, "hello.txt", "hello world");
+        String hash = "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447";
+        long mod = co.getMetadatumLong("modified", -1L);
+        assertTrue("Bad modified time: "+Long.toString(mod), mod > 0L);
+
+        JSONObject md = co.exportMetadata();
+        md.put("size", 12L);
+        md.put("checksum", hash);
+        md.put("checksumAlgorithm", "sha256");
+        co = new CacheObject(co.name, md, vol);
+
+        // all good
+        chk = new ChecksumCheck(false);
+        chk.check(co);
+
+        // now require matching dates; still good
+        chk = new ChecksumCheck(true);
+        chk.check(co);
+
+        // now muck with the modified date
+        md.put("modified", co.getMetadatumLong("modified", -1L)+2L);
+        co = new CacheObject(co.name, md, vol);
+        try {
+            chk.check(co);
+            fail("Failed to detect difference in mod time");
+        }
+        catch (ChecksumMismatchException ex) {
+            assertEquals("modified "+Long.toString(mod), ex.calculatedHash);
+            assertEquals(12L, ex.size);
+        }
     }
+
+    class HackVolume extends FilesystemCacheVolume {
+        public HackVolume(File root) throws IOException {
+            super(root);
+        }
+        public CacheObject get(String name) throws StorageVolumeException {
+            CacheObject out = super.get(name);
+            JSONObject md = out.exportMetadata();
+            md.put("volumeChecksum", "etag goober");
+            return new CacheObject(out.name, md, this);
+        }
+    }
+
+
+    @Test
+    public void testVolChecksumCheck() throws IOException, CacheManagementException, StorageVolumeException {
+        CacheObject co = makeobj(vol, "hello.txt", "hello world");
+        FilesystemCacheVolume hv = new HackVolume(vol.getRootDir());
+        String hash = "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447";
+        co = hv.get("hello.txt");
+        String vcs = co.getMetadatumString("volumeChecksum", "");
+        assertEquals("etag goober", vcs);
+
+        JSONObject md = co.exportMetadata();
+        md.put("size", 12L);
+        md.put("checksum", hash);
+        md.put("checksumAlgorithm", "sha256");
+        co = new CacheObject(co.name, md, hv);
+
+        // all good
+        chk = new ChecksumCheck(true, false);
+        chk.check(co);
+
+        // now leverage volume checksum; still good
+        chk = new ChecksumCheck(false, true);
+        chk.check(co);
+
+        // now muck with the volume checksum
+        md.put("volumeChecksum", "etag XXXXX");
+        co = new CacheObject(co.name, md, hv);
+        try {
+            chk.check(co);
+            fail("Failed to detect difference in volume checksum");
+        }
+        catch (ChecksumMismatchException ex) {
+            assertEquals("etag goober", ex.calculatedHash);
+            assertEquals(12L, ex.size);
+        }
+
+        // now muck with the modified time
+        md.put("modified", co.getMetadatumLong("modified", -1L)+2L);
+        co = new CacheObject(co.name, md, hv);
+        try {
+            chk.check(co);
+            fail("Failed to detect difference in modified time");
+        }
+        catch (ChecksumMismatchException ex) {
+            long mod = hv.get("hello.txt").getLastModified();
+            assertEquals("modified "+Long.toString(mod), ex.calculatedHash);
+            assertEquals(12L, ex.size);
+        }
+    }
+    
 }

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/inventory/ChecksumCheckTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/inventory/ChecksumCheckTest.java
@@ -62,7 +62,7 @@ public class ChecksumCheckTest {
     CacheObject makeobj(FilesystemCacheVolume v, String name, String contents) throws IOException {
         File out = _makefile(new File(v.getRootDir(), name), contents);
         JSONObject md = new JSONObject();
-        md.put("modified", out.lastModified());
+        md.put("modified", FilesystemCacheVolume.getLastModifiedTimeOf(out));
         return new CacheObject(name, md, v);
     }
 

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
@@ -240,6 +240,20 @@ public class AWSS3CacheVolumeTest {
         }
         assertTrue(s3client.doesObjectExist(bucket, objname));
         assertTrue(s3cv.exists("test.txt"));
+        assertTrue("metadata not updated with 'modified'", md.has("modified"));
+        long mod = md.getLong("modified");
+        assertTrue("Bad mod date: "+Long.toString(mod), mod > 0L);
+    }
+
+    @Test
+    public void testGet() throws StorageVolumeException {
+        byte[] obj = "hello world.\n".getBytes();
+        testSaveAs();
+        CacheObject co = s3cv.get("test.txt");
+        assertEquals(co.getSize(), obj.length);
+        long mod = co.getLastModified();
+        assertTrue("Bad mod time: "+Long.toString(mod), mod > 0L);
+        assertEquals(co.getMetadatumString("contentType",""), "text/plain");
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
@@ -243,6 +243,9 @@ public class AWSS3CacheVolumeTest {
         assertTrue("metadata not updated with 'modified'", md.has("modified"));
         long mod = md.getLong("modified");
         assertTrue("Bad mod date: "+Long.toString(mod), mod > 0L);
+        String vcs = md.getString("volumeChecksum");
+        assertTrue("Bad volume checksum: "+vcs,
+                   vcs.startsWith("etag ") && vcs.length() > 36);
     }
 
     @Test
@@ -276,6 +279,10 @@ public class AWSS3CacheVolumeTest {
         }
         assertTrue(s3client.doesObjectExist(bucket, objname));
         assertTrue(s3cv.exists("test.txt"));
+        assertEquals(md.getString("contentMD5"), "JjJWGp65Tg0F4+AyzFre7Q==");
+
+        // the etag should be an MD5 sum, but for some reason it is not
+        // assertEquals(md.getString("volumeChecksum"), "etag JjJWGp65Tg0F4+AyzFre7Q==");
     }
 
     /*


### PR DESCRIPTION
This PR enhances the distribution service's cache manager to allow for faster checksum checking of large files stored in AWS .  In the PDR configuration, large files are stored exclusively in AWS S3 buckets; running daily checksum checks, in which each file must be read in full and a checksum calculated, can quickly overwhelm the capacity of the server, so checking will invariably fall behind.  AWS S3, however, automatically calculates and stores an MD5-like hash when a file is put in the bucket; it can also calculate and store MD5, SHA-256, or other hashes if provided for on upload. This PR allows a calculated-on-upload hash to be used instead of a recalculated hash: if the `CacheObject` returned from a volume contains a "volumeChecksum" metadatum, the `ChecksumCheck` class will simply compare this value with the same metadatum stored in the cache inventory DB and ensure they are the same.  This substituted test assumes that the only way for the bytes in an object in the bucket to be changed is for a new version to be uploaded, which would trigger a change in the stored hash; thus, we rely on the built-in integrity controls of S3.  (This assumption is not true of EC2 store attached as a normal disk.)

As an extra guard, `ChecksumCheck` can also be set to check for a change in a file's modification time as fast-fail indicator before attempting a checksum check (just as a size check is currently used).  