### PR TITLE
ValidationHelper: avoid recursion of open connections on redirect

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/datapackage/ValidationHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/datapackage/ValidationHelper.java
@@ -95,11 +95,16 @@ public class ValidationHelper {
 	    String location = conn.getHeaderField("Location");
 	    
 	    if ((responseCode >= 300 && responseCode < 400) && allowedRedirects == 0) {
+                conn.disconnect();
+                conn = null;
 	    	return new URLStatusLocation(responseCode, location, url, 0, true);  	
 	    }
 
-	    if ((responseCode >= 300 && responseCode < 400) && allowedRedirects > 0)
+	    if ((responseCode >= 300 && responseCode < 400) && allowedRedirects > 0) {
+                conn.disconnect();
+                conn = null;
 		return checkURLStatusLocationSize(location, allowedRedirects);
+            }
             if (responseCode >= 400)
                 // avoids leaving open socket?
                 quietClose(conn.getErrorStream(), url+" (error stream)");


### PR DESCRIPTION
`ValidationHelper` is a utility class supporting data packaging; one of its functions is to probe URLs to requested data files for their existence and size.  Since there are/have been file URLs recorded in the PDR featuring circular redirects, the code is careful about limiting the number of times it can be redirected.  However, there is a bug in this code that fails to close the `HttpURLConnection` it uses before following a redirect.  As this connection spawns a thread to connect to the URL, this can lead to a thread leak.  One failure mode is that under heavy load, it is possible that the system runs out of available threads before the code exceeds its redirect limit.  This results in a `OutOfMemoryException` with an error message, "unable to create new  native thread".  This PR simply closes the connection explicitly before following the redirect.
