### PR TITLE
Fix bundling bug resulting in empty files in bundle

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/datapackage/DefaultDataPackager.java
+++ b/src/main/java/gov/nist/oar/distrib/datapackage/DefaultDataPackager.java
@@ -137,6 +137,7 @@ public class DefaultDataPackager implements DataPackager {
 					try {
 						URL obj = new URL(this.updateURL(uLoc.getRequestedURL()));
 						con = (HttpURLConnection) obj.openConnection();
+                                                con.setInstanceFollowRedirects(true);
 						fstream = con.getInputStream();
 						int len;
 						byte[] buf = new byte[100000];

--- a/src/main/java/gov/nist/oar/distrib/datapackage/ValidationHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/datapackage/ValidationHelper.java
@@ -84,7 +84,6 @@ public class ValidationHelper {
 
 	    URL obj = new URL(url);
 	    conn = (HttpURLConnection) obj.openConnection();
-	    HttpURLConnection.setFollowRedirects(false);
 	    conn.setInstanceFollowRedirects(false);
 	    conn.setConnectTimeout(10000); //  10 seconds
 	    conn.setReadTimeout(100000);   // 100 seconds


### PR DESCRIPTION
When data files are cached and thus can be delivered for download via an HTTP redirect, we were seeing these files appearing in data cart bundles as empty files.  This was caused by a call within `ValidationHelper` to the static function, `HttpURLConnection.setFollowRedirects(false)`; as this is a static function, this turns off support for redirects for all future `HttpURLConnection` instances.  Thus, this affected the instances used by `DefaultDataPackager` to load zip bundles, and caused them to be written as zero-length files.  

This PR removes this static call in `ValidationHelper`.  (It also called the non-static `HttpURLConnection.setInstanceFollowRedirects(false)`, which does the right thing.)  This PR also updates `DefaultDataPackager` to explicitly call `HttpURLConnection.setInstanceFollowRedirects(true)`, just to be certain that redirects are followed.  