### PR TITLE
Feature: Support for Restricted Public Access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ hs_err_pid*
 # IDEs
 # - Intellij
 .idea/
-
-# Logs
-*.log

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ hs_err_pid*
 /target/
 *.classpath
 *.project
+
+
+# IDEs
+# - Intellij
+.idea/
+
+# Logs
+*.log

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,23 @@
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
         </dependency>
+
+        <!-- dependencies user for RPA-->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>oar-dist-service</finalName>

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/BagCacher.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/BagCacher.java
@@ -485,7 +485,7 @@ public class BagCacher implements PDRCacheRoles {
             String file = nerd.optString("filepath");
             if (file == null) {
                 log.warn("NERDm DataFile record for id={}#{} ({}) is missing filepath property (skipping)",
-                         aipid, version, filename);
+                        aipid, version, filename);
                 return;
             }
 
@@ -497,18 +497,21 @@ public class BagCacher implements PDRCacheRoles {
             // if (nerd.has("size"))
             //     save.put("size", nerd.get("size"));
             if (nerd.has("checksum") && nerd.opt("checksum") != null &&
-                nerd.getJSONObject("checksum").has("hash") && nerd.getJSONObject("checksum").has("algorithm") &&
-                Checksum.SHA256.equals(nerd.getJSONObject("checksum")
-                                           .getJSONObject("algorithm").optString("tag")))
+                    nerd.getJSONObject("checksum").has("hash") && nerd.getJSONObject("checksum").has("algorithm") &&
+                    Checksum.SHA256.equals(nerd.getJSONObject("checksum")
+                            .getJSONObject("algorithm").optString("tag")))
             {
                 save.put("checksum", nerd.getJSONObject("checksum").getString("hash"));
                 save.put("checksumAlgorithm", nerd.getJSONObject("checksum")
-                                                  .getJSONObject("algorithm").optString("tag"));
+                        .getJSONObject("algorithm").optString("tag"));
             }
             save.put("aipid", aipid);
             save.put("version", version);
-            
+
             mdcache.cacheFileMetadata(aipid, version, save);
+
+        } else if (isTopLevelType(nerd)){
+            // TODO: check if top level file, and then call save
         }
     }
 
@@ -519,6 +522,20 @@ public class BagCacher implements PDRCacheRoles {
         for(Object el : types) {
             try {
                 if (((String) el).endsWith(":DataFile"))
+                    return true;
+            } catch (ClassCastException ex) { }
+        }
+        return false;
+    }
+
+    // check if resource type
+    boolean isTopLevelType(JSONObject cmp) {
+        JSONArray types = cmp.optJSONArray("@type");
+        if (types == null) return false;
+
+        for (Object el: types) {
+            try {
+                if (((String) el).endsWith(":Resource") || ((String) el).endsWith(":PublicDataResource"))
                     return true;
             } catch (ClassCastException ex) { }
         }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
@@ -174,10 +174,10 @@ public class PDRCacheManager extends BasicCacheManager implements PDRConstants, 
      *                    fresh copy.
      * @param version  the desired version of the dataset or null for the latest version
      */
-    public void cacheDataset(String dsid, String version, boolean recache, int prefs, String target)
+    public Set<String> cacheDataset(String dsid, String version, boolean recache, int prefs, String target)
         throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
     {
-        ((PDRDatasetRestorer) restorer).cacheDataset(dsid, version, theCache, recache, prefs, target);
+        return ((PDRDatasetRestorer) restorer).cacheDataset(dsid, version, theCache, recache, prefs, target);
     }
 
     /**

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
@@ -174,10 +174,10 @@ public class PDRCacheManager extends BasicCacheManager implements PDRConstants, 
      *                    fresh copy.
      * @param version  the desired version of the dataset or null for the latest version
      */
-    public void cacheDataset(String dsid, String version, boolean recache)
+    public void cacheDataset(String dsid, String version, boolean recache, int prefs, String target)
         throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
     {
-        ((PDRDatasetRestorer) restorer).cacheDataset(dsid, version, theCache, recache);
+        ((PDRDatasetRestorer) restorer).cacheDataset(dsid, version, theCache, recache, prefs, target);
     }
 
     /**
@@ -1003,7 +1003,7 @@ public class PDRCacheManager extends BasicCacheManager implements PDRConstants, 
             try {
                 if (parts[1].length() == 0) 
                     // dataset identifier
-                    cacheDataset(parts[0], version, recache);
+                    cacheDataset(parts[0], version, recache, 0, null);
                 else if (recache || ! isCached(nextid))
                     // data file identifier
                     cache(nextid, true);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheRoles.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheRoles.java
@@ -49,4 +49,14 @@ public interface PDRCacheRoles {
      */
     int ROLE_OLD_VERSIONS = 16;
 
+    /**
+     * a preference code assigned to cache volumes intended to hold Restricted Public Data (RPD)
+     */
+    int ROLE_RESTRICTED_DATA = 32;
+
+    /**
+     * a preference code assigned to cache volumes intended to hold deprecated versions of Restricted Public Data (RPD)
+     */
+    int ROLE_OLD_RESTRICTED_DATA = 64;
+
 }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
@@ -567,9 +567,10 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
                 String filepath = fname.subpath(2, fname.getNameCount()).toString();
                 if (need != null && ! need.contains(filepath))
                     continue;
-                id = aipid+"/"+filepath;
-                if (forVersion != null)
-                    id += "#"+forVersion;
+//                id = aipid+"/"+filepath;
+//                if (forVersion != null)
+//                    id += "#"+forVersion;
+                id = idForObject(aipid, filepath, forVersion, target);
 
                 if (into.isCached(id)) {
                     if (recache)
@@ -636,6 +637,20 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
         if (fix.size() > 0 && manifest != null)
             fixMissingChecksums(into, fix, manifest);
     }
+
+    /**
+     * helper method to generate an ID for the object to be cached
+     */
+    public String idForObject(String aipid, String filepath, String forVersion, String target) {
+        String id;
+        id = aipid + "/" + filepath;
+        if (target != null && !target.isEmpty())
+            id = target + "/" + filepath;
+        if (forVersion != null && forVersion.length() > 0)
+            id += "#" + forVersion;
+        return id;
+    }
+
 
     private Map<String,String> extractFromManifest(InputStream manifest, Collection<String> need)
         throws IOException

--- a/src/main/java/gov/nist/oar/distrib/service/DataCachingService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/DataCachingService.java
@@ -1,0 +1,22 @@
+package gov.nist.oar.distrib.service;
+
+import gov.nist.oar.distrib.ResourceNotFoundException;
+import gov.nist.oar.distrib.StorageVolumeException;
+import gov.nist.oar.distrib.cachemgr.CacheManagementException;
+
+import java.util.Set;
+
+/**
+ * Service interface for caching all the data that is part of a given version of a dataset.
+ */
+public interface DataCachingService {
+
+    /**
+     * cache all data that is part of the given version of a dataset.
+     * @param datasetID    the identifier for the dataset.
+     * @param version  the version of the dataset to cache.  If null, the latest is cached.
+     *
+     * @return Set<String> -- a list of the URLs for files that were cached
+     */
+    Set<String> cacheDataset(String datasetID, String version) throws CacheManagementException, ResourceNotFoundException, StorageVolumeException;
+}

--- a/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
@@ -1,0 +1,154 @@
+package gov.nist.oar.distrib.service;
+
+import gov.nist.oar.distrib.ResourceNotFoundException;
+import gov.nist.oar.distrib.StorageVolumeException;
+import gov.nist.oar.distrib.cachemgr.CacheManagementException;
+import gov.nist.oar.distrib.cachemgr.CacheObject;
+import gov.nist.oar.distrib.cachemgr.pdr.PDRCacheManager;
+import gov.nist.oar.distrib.cachemgr.pdr.PDRCacheRoles;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * A DataCachingService implementation that leverages the {@link PDRCacheManager} to cache a dataset.
+ * <p>
+ * todo@omar: add story/description of the service
+ * <p>
+ * This implementation uses the {@link PDRCacheManager} to cache a dataset of Restricted Public Data.
+ */
+public class RPACachingService implements DataCachingService, PDRCacheRoles {
+
+    private PDRCacheManager pdrCacheManager = null;
+
+    protected static Logger logger = LoggerFactory.getLogger(RPACachingService.class);
+
+    HashMap<String, String> url2dsid;
+
+    /**
+     * Create an instance of the service that wraps a {@link PDRCacheManager}
+     *
+     * @param pdrCacheManager the PDRCacheManager to use to store the restricted public data.
+     **/
+    public RPACachingService(PDRCacheManager pdrCacheManager) {
+        this.pdrCacheManager = pdrCacheManager;
+    }
+
+    /**
+     * Cache all data that is part of the given version of a dataset.
+     *
+     * @param datasetID the identifier for the dataset.
+     * @param version   the version of the dataset to cache.  If null, the latest is cached.
+     * @return Set<String> -- a list of the URLs for files that were cached
+     */
+    // todo@omar: test me
+    public Set<String> cacheDataset(String datasetID, String version)
+            throws CacheManagementException, ResourceNotFoundException, StorageVolumeException {
+
+        String randomID = generateRandomID(20, true, true);
+
+        int prefs = ROLE_RESTRICTED_DATA;
+        if (!version.isEmpty())
+            prefs = ROLE_OLD_RESTRICTED_DATA;
+
+        Set<String> temporaryUrls = new HashSet<>();
+        this.pdrCacheManager.cacheDataset(datasetID, version, true, prefs, randomID).forEach(name ->
+                {
+                    temporaryUrls.add("/" + randomID + "/" + name);
+                }
+        );
+        return temporaryUrls;
+    }
+
+    /**
+     * Cache all data that is part of the given version of a dataset, and generate a temporary URL.
+     *
+     * @param datasetID the identifier for the dataset.
+     * @param version   the version of the dataset to cache.  If null, the latest is cached.
+     * @return String -- the temporary URL that will be used to fetch the files metadata.
+     */
+    public String cacheAndGenerateTemporaryUrl(String datasetID, String version)
+            throws CacheManagementException, ResourceNotFoundException, StorageVolumeException {
+
+        String baseDataCartURL = "https://data.nist.gov/pdr/datacart/restricted_datacart";
+        String randomID = generateRandomID(20, true, true);
+
+        int prefs = ROLE_RESTRICTED_DATA;
+        if (!version.isEmpty())
+            prefs = ROLE_OLD_RESTRICTED_DATA;
+
+        // cache dataset
+        this.pdrCacheManager.cacheDataset(datasetID, version, true, prefs, randomID);
+        return baseDataCartURL + "/" + randomID;
+    }
+
+
+    public Map<String, Object> retrieveMetadata(String randomID) throws CacheManagementException {
+        JSONArray metadata = new JSONArray();
+        List<CacheObject> objects = this.pdrCacheManager.selectDatasetObjects(randomID, this.pdrCacheManager.VOL_FOR_INFO);
+        if (objects.size() > 0) {
+            for (CacheObject obj: objects) {
+                JSONObject objMd = formatMetadata(obj.exportMetadata(), randomID);
+                metadata.put(objMd);
+            }
+        }
+        JSONObject result = new JSONObject();
+        result.put("randomId", randomID);
+        result.put("metadata", metadata);
+        return result.toMap();
+    }
+
+    private JSONObject formatMetadata(JSONObject inMd, String randomID) {
+        String baseDownloadURL = "http://localhost:8083/od/ds/";
+
+        JSONObject outMd = new JSONObject();
+        if (inMd.has("filepath")) {
+            String downloadURL = baseDownloadURL + randomID + "/" + inMd.get("filepath");
+            outMd.put("downloadURL", downloadURL);
+            outMd.put("filePath", inMd.get("filepath"));
+        }
+        if (inMd.has("contentType")) {
+            outMd.put("mediaType", inMd.get("contentType"));
+        }
+        if (inMd.has("size")) {
+            outMd.put("size", inMd.get("size"));
+        }
+        if (inMd.has("resTitle")) {
+            outMd.put("resTitle", inMd.get("resTitle"));
+        }
+        if (inMd.has("pdrid")) {
+            outMd.put("resId", inMd.get("pdrid"));
+        }
+        if (inMd.has("checksumAlgorithm")) {
+            outMd.put("checksumAlgorithm", inMd.get("checksumAlgorithm"));
+        }
+        if (inMd.has("checksum")) {
+            outMd.put("checksum", inMd.get("checksum"));
+        }
+        if (inMd.has("version")) {
+            outMd.put("version", inMd.get("version"));
+        }
+        if (inMd.has("ediid")) {
+            outMd.put("ediid", inMd.get("ediid"));
+        }
+        if (inMd.has("aipid")) {
+            outMd.put("aipid", inMd.get("aipid"));
+        }
+        if (inMd.has("sinceDate")) {
+            outMd.put("sinceDate", inMd.get("sinceDate"));
+        }
+        return outMd;
+    }
+
+    /**
+     * Generate a random alphanumeric string for the dataset to store
+     * This function uses the {@link RandomStringUtils} from Apache Commons.
+     **/
+    private String generateRandomID(int length, boolean useLetters, boolean useNumbers) {
+        return RandomStringUtils.random(length, useLetters, useNumbers);
+    }
+}

--- a/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
@@ -86,7 +86,35 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
         return baseDataCartURL + "?id=" + randomID;
     }
 
+    /**
+     * Cache all data that is part of the given version of a dataset, and generate a temporary random id.
+     *
+     * @param datasetID the identifier for the dataset.
+     * @param version   the version of the dataset to cache.  If null, the latest is cached.
+     * @return String -- the temporary random that will be used to fetch metadata.
+     */
+    public String cacheAndGenerateRandomId(String datasetID, String version)
+            throws CacheManagementException, ResourceNotFoundException, StorageVolumeException {
 
+        String randomID = generateRandomID(20, true, true);
+
+        int prefs = ROLE_RESTRICTED_DATA;
+        if (!version.isEmpty())
+            prefs = ROLE_OLD_RESTRICTED_DATA;
+
+        // cache dataset
+        this.pdrCacheManager.cacheDataset(datasetID, version, true, prefs, randomID);
+        return randomID;
+    }
+
+
+    /**
+     * Retrieve metadata given the random id that was previously generated and used to cache the dataset.
+     *
+     * @param randomID the random ID used to cache the dataset.
+     *
+     * @return Map<String, Object> -- metadata about files in dataset
+     */
     public Map<String, Object> retrieveMetadata(String randomID) throws CacheManagementException {
         JSONArray metadata = new JSONArray();
         List<CacheObject> objects = this.pdrCacheManager.selectDatasetObjects(randomID, this.pdrCacheManager.VOL_FOR_INFO);

--- a/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
@@ -83,7 +83,7 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
 
         // cache dataset
         this.pdrCacheManager.cacheDataset(datasetID, version, true, prefs, randomID);
-        return baseDataCartURL + "/" + randomID;
+        return baseDataCartURL + "?id=" + randomID;
     }
 
 

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultKeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultKeyRetriever.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa;public class DefaultKeyRetriever {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultKeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultKeyRetriever.java
@@ -1,2 +1,36 @@
-package gov.nist.oar.distrib.service.rpa;public class DefaultKeyRetriever {
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.web.RPAConfiguration;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+/**
+ * Default implementation of the KeyRetriever interface.
+ * This loads a private statically, where the private key is defined in this class as a constant string.
+ */
+public class DefaultKeyRetriever implements KeyRetriever {
+
+    private static final String KEY = "-----BEGIN PRIVATE KEY-----" +
+            "<<<<<PRIVATE_KEY_CONTENT_GOES_HERE>>>>>"+
+            "-----END PRIVATE KEY-----";
+
+    @Override
+    public Key getKey(RPAConfiguration rpaConfiguration) {
+        String privateKey = KEY.replace("-----BEGIN PRIVATE KEY-----", "");
+        privateKey = privateKey.replace("-----END PRIVATE KEY-----", "");
+        privateKey = privateKey.replaceAll("\\s+", "");
+
+        byte[] decode = Base64.getDecoder().decode(privateKey);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decode);
+        try {
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            return kf.generatePrivate(keySpec);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception during key generation");
+        }
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -246,6 +246,7 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
                 .queryParam("grant_type", getConfig().getSalesforceJwt().getGrantType())
                 .queryParam("assertion", assertion)
                 .toUriString();
+        LOGGER.info("Token request URL = " + url);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return restTemplate.postForObject(url, new HttpEntity<>(null, headers), SalesforceToken.class);

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -14,11 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -44,6 +41,8 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
         this.keyRetriever = keyRetriever;
         this.restTemplate = new RestTemplate();
         this.patchRestTemplate = new RestTemplate();
+
+        LOGGER.info("Using configuration: " + this.rpaConfiguration.toString());
     }
 
     public RPAConfiguration getConfig() { return this.rpaConfiguration; }
@@ -251,24 +250,9 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
                 .queryParam("grant_type", getConfig().getSalesforceJwt().getGrantType())
                 .queryParam("assertion", assertion)
                 .toUriString();
-        LOGGER.info("Token request URL = " + url);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        String tokenStr = null;
-        try {
-            tokenStr = restTemplate.postForObject(url, new HttpEntity<>(null, headers), String.class);
-        } catch (HttpStatusCodeException e) {
-            throw new RuntimeException(e);
-        }
-        LOGGER.info("tokenStr = " + tokenStr);
-        ObjectMapper objectMapper = new ObjectMapper();
-        SalesforceToken token = null;
-        try {
-            token = objectMapper.readValue(tokenStr, SalesforceToken.class);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return token;
+        return restTemplate.postForObject(url, new HttpEntity<>(null, headers), SalesforceToken.class);
     }
 
 

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa;public class DefaultRPARequestHandlerService {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -1,2 +1,255 @@
-package gov.nist.oar.distrib.service.rpa;public class DefaultRPARequestHandlerService {
+package gov.nist.oar.distrib.service.rpa;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nist.oar.distrib.service.rpa.model.*;
+import gov.nist.oar.distrib.web.RPAConfiguration;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.*;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@RequiredArgsConstructor
+public class DefaultRPARequestHandlerService implements RPARequestHandlerService {
+
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(DefaultRPARequestHandlerService.class);
+    private final static String API_TEST_ENDPOINT_KEY = "api-test-endpoint";
+    private final static String GET_RECORD_ENDPOINT_KEY = "get-record-endpoint";
+    private final static String CREATE_RECORD_ENDPOINT_KEY = "create-record-endpoint";
+    private final static String UPDATE_RECORD_ENDPOINT_KEY = "update-record-endpoint";
+    private final static String SEND_EMAIL_ENDPOINT_KEY = "send-email-endpoint";
+
+    private RPAConfiguration rpaConfiguration = null;
+    private KeyRetriever keyRetriever = null;
+    private RestTemplate restTemplate;
+    private RestTemplate patchRestTemplate;
+
+    public DefaultRPARequestHandlerService(RPAConfiguration rpaConfiguration, KeyRetriever keyRetriever) {
+        this.rpaConfiguration = rpaConfiguration;
+        this.keyRetriever = keyRetriever;
+    }
+
+    public RPAConfiguration getConfig() { return this.rpaConfiguration; }
+
+
+    @Override
+    public RecordWrapper getRecord(String recordId) {
+        String getRecordUri = getConfig().getSalesforceEndpoints().get(GET_RECORD_ENDPOINT_KEY);
+        SalesforceToken token = getToken();
+        HttpHeaders headers = getHttpHeaders(token, null);
+        String url = UriComponentsBuilder.fromUriString(token.getInstanceUrl())
+                .path(getRecordUri + "/" + recordId)
+                .toUriString();
+        ResponseEntity<RecordWrapper> response = restTemplate.exchange(url, HttpMethod.GET,
+                new HttpEntity<>(headers), RecordWrapper.class);
+        return response.getBody();
+    }
+
+    @Override
+    public RecordWrapper createRecord(UserInfoWrapper userInfoWrapper) {
+        String createRecordUri = getConfig().getSalesforceEndpoints().get(CREATE_RECORD_ENDPOINT_KEY);
+        SalesforceToken token = getToken();
+        HttpHeaders headers = getHttpHeaders(token, MediaType.APPLICATION_JSON);
+        HttpEntity<String> request;
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            String payload = mapper.writeValueAsString(userInfoWrapper);
+            LOGGER.debug("PAYLOAD=" + payload);
+            request = new HttpEntity<>(mapper.writeValueAsString(userInfoWrapper), headers);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        String url = token.getInstanceUrl() + createRecordUri;
+        ResponseEntity<RecordWrapper> responseEntity = restTemplate.exchange(url, HttpMethod.POST, request, RecordWrapper.class);
+
+        if (responseEntity.getStatusCode().equals(HttpStatus.OK)) {
+            onSuccessfulRecordCreation(responseEntity.getBody().getRecord());
+        } else {
+            onFailedRecordCreation(responseEntity.getStatusCode());
+        }
+        return responseEntity.getBody();
+    }
+
+
+    private void onSuccessfulRecordCreation(Record record) {
+        LOGGER.info("Record created successfully! Now sending emails...");
+        if (sendConfirmationEmailToEndUser(record).equals(HttpStatus.OK)) {
+            LOGGER.info("Confirmation email sent to end user successfully!");
+        }
+        if (sendApprovalEmailToSME(record).equals(HttpStatus.OK)) {
+            LOGGER.info("Request approval email sent to subject matter expert successfully!");
+        }
+    }
+
+    private void onFailedRecordCreation(HttpStatus statusCode) {
+        // handle failed record creation
+    }
+
+
+    @Override
+    public RecordStatus updateRecord(String recordId, String status) {
+        String updateRecordUri = getConfig().getSalesforceEndpoints().get(UPDATE_RECORD_ENDPOINT_KEY);
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        patchRestTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClient));
+        JSONObject updateBody = new JSONObject();
+        updateBody.put("Approval_Status__c", status);
+        SalesforceToken token = getToken();
+        HttpHeaders headers = getHttpHeaders(token, MediaType.APPLICATION_JSON);
+        String patch = updateBody.toString();
+        LOGGER.debug("PATCH_DATA=" + patch);
+        HttpEntity<String> request = new HttpEntity<>(patch, headers);
+        String url = UriComponentsBuilder.fromUriString(token.getInstanceUrl())
+                .path(updateRecordUri + "/" + recordId)
+                .toUriString();
+        ResponseEntity<RecordStatus> responseEntity = patchRestTemplate.exchange(
+                url, HttpMethod.PATCH, request, RecordStatus.class
+        );
+        // check if status is approved and trigger the caching process
+        LOGGER.debug("APPROVAL_STATUS=" + responseEntity.getBody().getApprovalStatus());
+        if (responseEntity.getBody().getApprovalStatus().equalsIgnoreCase("approved")) {
+            onEndUserApproved(recordId);
+        }
+        // check if status is declined and send email notification to user
+        if (responseEntity.getBody().getApprovalStatus().equalsIgnoreCase("declined")) {
+            onEndUserDeclined(recordId);
+        }
+        return responseEntity.getBody();
+    }
+
+    private HttpStatus onEndUserApproved(String recordId) {
+        LOGGER.info("User was approved by SME. Starting caching...");
+        Record record = getRecord(recordId).getRecord();
+        // ID/subject starts with 'RPA: ', so we need to remove to extract the ID
+        String datasetId = record.getUserInfo().getSubject().replace("RPA: ", "");
+        String dataCartUrl = startCaching(datasetId);
+        LOGGER.info("Dataset was cached successfully. Sending email to user...");
+        return sendDownloadEmailToEndUser(record, dataCartUrl);
+    }
+
+    private HttpStatus onEndUserDeclined(String recordId) {
+        LOGGER.info("User was declined by SME. Sending declined email to user...");
+        Record record = getRecord(recordId).getRecord();
+        return sendDeclinedEmailToEndUser(record);
+    }
+
+    // Function to call the caching the service to start the caching process
+    // This function returns a temporary URL to the datacart that contains the cached dataset
+    private String startCaching(String datasetId) {
+        String url = getConfig().getPdrCachingUrl() + datasetId;
+        HttpEntity<String> request = new HttpEntity<>(null, new HttpHeaders());
+        ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.PUT, request, String.class);
+        return responseEntity.getBody();
+    }
+
+    private HttpStatus sendApprovalEmailToSME(Record record) {
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
+                EmailHelper.getSMEApprovalEmailInfo(record, getConfig())
+        );
+        return responseEntity.getStatusCode();
+    }
+
+    private HttpStatus sendConfirmationEmailToEndUser(Record record) {
+        if (record.getUserInfo().getReceiveEmails().equalsIgnoreCase("no")) {
+            return HttpStatus.CONTINUE;
+        }
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
+                EmailHelper.getEndUserConfirmationEmailInfo(record, getConfig())
+        );
+        return responseEntity.getStatusCode();
+    }
+
+    private HttpStatus sendDownloadEmailToEndUser(Record record, String datacartUrl) {
+        if (record.getUserInfo().getReceiveEmails().equalsIgnoreCase("no")) {
+            return HttpStatus.CONTINUE;
+        }
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
+                EmailHelper.getEndUserDownloadEmailInfo(record, getConfig(), datacartUrl)
+        );
+        return responseEntity.getStatusCode();
+    }
+
+    private HttpStatus sendDeclinedEmailToEndUser(Record record) {
+        if (record.getUserInfo().getReceiveEmails().equalsIgnoreCase("no")) {
+            return HttpStatus.CONTINUE;
+        }
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
+                EmailHelper.getEndUserDeclinedEmailInfo(record, getConfig())
+        );
+        return responseEntity.getStatusCode();
+    }
+
+
+    private ResponseEntity<EmailInfoWrapper> sendEmail(EmailInfo emailInfo) {
+        String sendEmailUri = getConfig().getSalesforceEndpoints().get(SEND_EMAIL_ENDPOINT_KEY);
+        SalesforceToken token = getToken();
+        HttpHeaders headers = getHttpHeaders(token, MediaType.APPLICATION_JSON);
+        ObjectMapper mapper = new ObjectMapper();
+        HttpEntity<String> request;
+        try {
+            request = new HttpEntity<>(mapper.writeValueAsString(emailInfo), headers);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        String url = token.getInstanceUrl() + sendEmailUri;
+        return restTemplate.exchange(url, HttpMethod.POST, request, EmailInfoWrapper.class);
+    }
+
+
+    public String testSalesforceAPIConnection() {
+        String testUri = getConfig().getSalesforceEndpoints().get(API_TEST_ENDPOINT_KEY);
+        SalesforceToken token = getToken();
+        HttpHeaders headers = getHttpHeaders(token, null);
+        ResponseEntity<String> response = restTemplate.exchange(token.getInstanceUrl() + testUri,
+                HttpMethod.GET, new HttpEntity<>(headers), String.class);
+        return response.getBody();
+    }
+
+    private HttpHeaders getHttpHeaders(SalesforceToken token, MediaType mediaType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token.getAccessToken());
+        if (mediaType != null)
+            headers.setContentType(mediaType);
+        return headers;
+    }
+
+    // JWT methods
+    private SalesforceToken getToken() {
+        return sendTokenRequest(createAssertion());
+    }
+
+    private String createAssertion() {
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(getConfig().getSalesforceJwt().getExpirationInMinutes());
+        return Jwts.builder()
+                .setIssuer(getConfig().getSalesforceJwt().getClientId())
+                .setAudience(getConfig().getSalesforceJwt().getAudience())
+                .setSubject(getConfig().getSalesforceJwt().getSubject())
+                .setExpiration(Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant()))
+                .signWith(SignatureAlgorithm.RS256, keyRetriever.getKey(getConfig()))
+                .compact();
+    }
+
+    private SalesforceToken sendTokenRequest(String assertion) {
+        String url = UriComponentsBuilder.fromUriString(getConfig().getSalesforceInstanceUrl())
+                .path("/services/oauth2/token")
+                .queryParam("grant_type", getConfig().getSalesforceJwt().getGrantType())
+                .queryParam("assertion", assertion)
+                .toUriString();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return restTemplate.postForObject(url, new HttpEntity<>(null, headers), SalesforceToken.class);
+    }
+
+
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -251,7 +252,12 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
         LOGGER.info("Token request URL = " + url);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        String tokenStr = restTemplate.postForObject(url, new HttpEntity<>(null, headers), String.class);
+        String tokenStr = null;
+        try {
+            tokenStr = restTemplate.postForObject(url, new HttpEntity<>(null, headers), String.class);
+        } catch (HttpStatusCodeException e) {
+            throw new RuntimeException(e);
+        }
         LOGGER.info("tokenStr = " + tokenStr);
         ObjectMapper objectMapper = new ObjectMapper();
         SalesforceToken token = null;

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -162,30 +162,30 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
     }
 
     private HttpStatus sendApprovalEmailToSME(Record record) {
-        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
-                EmailHelper.getSMEApprovalEmailInfo(record, getConfig())
-        );
+        EmailInfo emailInfo = EmailHelper.getSMEApprovalEmailInfo(record, getConfig());
+        LOGGER.info("EMAIL_INFO=" + emailInfo);
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(emailInfo);
         return responseEntity.getStatusCode();
     }
 
     private HttpStatus sendConfirmationEmailToEndUser(Record record) {
-        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
-                EmailHelper.getEndUserConfirmationEmailInfo(record, getConfig())
-        );
+        EmailInfo emailInfo = EmailHelper.getEndUserConfirmationEmailInfo(record, getConfig());
+        LOGGER.info("EMAIL_INFO=" + emailInfo);
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(emailInfo);
         return responseEntity.getStatusCode();
     }
 
     private HttpStatus sendDownloadEmailToEndUser(Record record, String downloadUrl) {
-        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
-                EmailHelper.getEndUserDownloadEmailInfo(record, getConfig(), downloadUrl)
-        );
+        EmailInfo emailInfo = EmailHelper.getEndUserDownloadEmailInfo(record, getConfig(), downloadUrl);
+        LOGGER.info("EMAIL_INFO=" + emailInfo);
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(emailInfo);
         return responseEntity.getStatusCode();
     }
 
     private HttpStatus sendDeclinedEmailToEndUser(Record record) {
-        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(
-                EmailHelper.getEndUserDeclinedEmailInfo(record, getConfig())
-        );
+        EmailInfo emailInfo = EmailHelper.getEndUserDeclinedEmailInfo(record, getConfig());
+        LOGGER.info("EMAIL_INFO=" + emailInfo);
+        ResponseEntity<EmailInfoWrapper> responseEntity = this.sendEmail(emailInfo);
         return responseEntity.getStatusCode();
     }
 

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -42,6 +42,8 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
     public DefaultRPARequestHandlerService(RPAConfiguration rpaConfiguration, KeyRetriever keyRetriever) {
         this.rpaConfiguration = rpaConfiguration;
         this.keyRetriever = keyRetriever;
+        this.restTemplate = new RestTemplate();
+        this.patchRestTemplate = new RestTemplate();
     }
 
     public RPAConfiguration getConfig() { return this.rpaConfiguration; }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/DefaultRPARequestHandlerService.java
@@ -16,6 +16,8 @@ import org.springframework.http.*;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -249,7 +251,16 @@ public class DefaultRPARequestHandlerService implements RPARequestHandlerService
         LOGGER.info("Token request URL = " + url);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        return restTemplate.postForObject(url, new HttpEntity<>(null, headers), SalesforceToken.class);
+        String tokenStr = restTemplate.postForObject(url, new HttpEntity<>(null, headers), String.class);
+        LOGGER.info("tokenStr = " + tokenStr);
+        ObjectMapper objectMapper = new ObjectMapper();
+        SalesforceToken token = null;
+        try {
+            token = objectMapper.readValue(tokenStr, SalesforceToken.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return token;
     }
 
 

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/EmailHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/EmailHelper.java
@@ -1,2 +1,108 @@
-package gov.nist.oar.distrib.service.rpa;public class EmailHelper {
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.service.rpa.model.EmailInfo;
+import gov.nist.oar.distrib.service.rpa.model.Record;
+import gov.nist.oar.distrib.web.RPAConfiguration;
+import org.apache.commons.text.StringSubstitutor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper class for sending emails.
+ */
+public class EmailHelper {
+
+    /**
+     * Get email to be sent to the SME for approving a request.
+     * @param record - the record this email is related to
+     * @param rpaConfiguration - the RPA configuration
+     *
+     * @return EmailInfo - email information (recipient, content, subject)
+     */
+    public static EmailInfo getSMEApprovalEmailInfo(Record record, RPAConfiguration rpaConfiguration) {
+        String recordId = record.getId();
+        String datasetId = record.getUserInfo().getSubject().replace("RPA: ", "");
+        String smeEmailAddress = rpaConfiguration.getApprovers().get(datasetId).getEmail();
+        String subject = rpaConfiguration.getSMEApprovalEmail().getSubject() + record.getCaseNum();
+        String content = StringSubstitutor.replace(
+                rpaConfiguration.getSMEApprovalEmail().getContent(),
+                getNamedPlaceholders(record, null),
+                "${", "}");
+        return new EmailInfo(recordId, smeEmailAddress, subject, content);
+    }
+
+    /**
+     * Get email to be sent to the End User to confirm receiving their request.
+     * @param record - the record this email is related to
+     * @param rpaConfiguration - the RPA configuration
+     *
+     * @return EmailInfo - email information (recipient, content, subject)
+     */
+    public static EmailInfo getEndUserConfirmationEmailInfo(Record record, RPAConfiguration rpaConfiguration) {
+        String recordId = record.getId();
+        String endUserEmailAddress = record.getUserInfo().getEmail();
+        String subject = rpaConfiguration.getEndUserConfirmationEmail().getSubject();
+        String content = StringSubstitutor.replace(
+                rpaConfiguration.getEndUserConfirmationEmail().getContent(),
+                getNamedPlaceholders(record, null),
+                "${", "}");
+        return new EmailInfo(recordId, endUserEmailAddress, subject, content);
+    }
+
+    /**
+     * Get email to be sent to the End User notifying them that the request has been approved.
+     * @param record - the record this email is related to
+     * @param rpaConfiguration - the RPA configuration
+     * @param datacartUrl - the URL where the End User will download their data
+     *
+     * @return EmailInfo - email information (recipient, content, subject)
+     */
+    public static EmailInfo getEndUserDownloadEmailInfo(Record record, RPAConfiguration rpaConfiguration, String datacartUrl) {
+        String recordId = record.getId();
+        String endUserEmailAddress = record.getUserInfo().getEmail();
+        String subject = rpaConfiguration.getEndUserApprovedEmail().getSubject();
+        String content = StringSubstitutor.replace(
+                rpaConfiguration.getEndUserApprovedEmail().getContent(),
+                getNamedPlaceholders(record, datacartUrl),
+                "${", "}");
+        return new EmailInfo(recordId, endUserEmailAddress, subject, content);
+    }
+
+    /**
+     * Get email to be sent to the End User notifying them that the request has been declined.
+     * @param record - the record this email is related to
+     * @param rpaConfiguration - the RPA configuration
+     *
+     * @return EmailInfo - email information (recipient, content, subject)
+     */
+    public static EmailInfo getEndUserDeclinedEmailInfo(Record record, RPAConfiguration rpaConfiguration) {
+        String recordId = record.getId();
+        String endUserEmailAddress = record.getUserInfo().getEmail();
+        String subject = rpaConfiguration.getEndUserDeclinedEmail().getSubject();
+        String content = StringSubstitutor.replace(
+                rpaConfiguration.getEndUserApprovedEmail().getContent(),
+                getNamedPlaceholders(record, null),
+                "${", "}");
+        return new EmailInfo(recordId, endUserEmailAddress, subject, content);
+    }
+
+    /**
+     * Helper method to load named placeholders used with email content templates.
+     */
+    private static Map<String ,Object> getNamedPlaceholders(Record record, String datacartUrl) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("RECORD_ID", record.getId());
+        map.put("CASE_NUMBER", record.getCaseNum());
+        map.put("FULL_NAME", record.getUserInfo().getFullName());
+        map.put("ORGANIZATION", record.getUserInfo().getOrganization());
+        map.put("COUNTRY", record.getUserInfo().getCountry());
+        map.put("EMAIL", record.getUserInfo().getEmail());
+        map.put("APPROVAL_STATUS", record.getUserInfo().getApprovalStatus());
+        map.put("DATASET_ID", record.getUserInfo().getSubject().replace("RPA: ", ""));
+        map.put("DATASET_NAME", record.getUserInfo().getProductTitle());
+        if (datacartUrl != null)
+            map.put("DATA_CART_URL", datacartUrl);
+        return map;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/EmailHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/EmailHelper.java
@@ -54,17 +54,17 @@ public class EmailHelper {
      * Get email to be sent to the End User notifying them that the request has been approved.
      * @param record - the record this email is related to
      * @param rpaConfiguration - the RPA configuration
-     * @param datacartUrl - the URL where the End User will download their data
+     * @param downloadUrl - the URL where the End User will download their data
      *
      * @return EmailInfo - email information (recipient, content, subject)
      */
-    public static EmailInfo getEndUserDownloadEmailInfo(Record record, RPAConfiguration rpaConfiguration, String datacartUrl) {
+    public static EmailInfo getEndUserDownloadEmailInfo(Record record, RPAConfiguration rpaConfiguration, String downloadUrl) {
         String recordId = record.getId();
         String endUserEmailAddress = record.getUserInfo().getEmail();
         String subject = rpaConfiguration.getEndUserApprovedEmail().getSubject();
         String content = StringSubstitutor.replace(
                 rpaConfiguration.getEndUserApprovedEmail().getContent(),
-                getNamedPlaceholders(record, datacartUrl),
+                getNamedPlaceholders(record, downloadUrl),
                 "${", "}");
         return new EmailInfo(recordId, endUserEmailAddress, subject, content);
     }
@@ -90,7 +90,7 @@ public class EmailHelper {
     /**
      * Helper method to load named placeholders used with email content templates.
      */
-    private static Map<String ,Object> getNamedPlaceholders(Record record, String datacartUrl) {
+    private static Map<String ,Object> getNamedPlaceholders(Record record, String downloadUrl) {
         Map<String, Object> map = new HashMap<>();
         map.put("RECORD_ID", record.getId());
         map.put("CASE_NUMBER", record.getCaseNum());
@@ -101,8 +101,8 @@ public class EmailHelper {
         map.put("APPROVAL_STATUS", record.getUserInfo().getApprovalStatus());
         map.put("DATASET_ID", record.getUserInfo().getSubject().replace("RPA: ", ""));
         map.put("DATASET_NAME", record.getUserInfo().getProductTitle());
-        if (datacartUrl != null)
-            map.put("DATA_CART_URL", datacartUrl);
+        if (downloadUrl != null)
+            map.put("DOWNLOAD_URL", downloadUrl);
         return map;
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/EmailHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/EmailHelper.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa;public class EmailHelper {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa;public class JKSKeyRetriever {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
@@ -1,15 +1,21 @@
 package gov.nist.oar.distrib.service.rpa;
 
 import gov.nist.oar.distrib.web.RPAConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Key;
 import java.security.KeyStore;
 
 public class JKSKeyRetriever implements KeyRetriever {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(JKSKeyRetriever.class);
     @Override
     public Key getKey(RPAConfiguration rpaConfiguration)  {
         try {
+            LOGGER.info("Using Java Keystore located at " + rpaConfiguration.getJksConfig().getKeyStorePath());
             KeyStore keystore = KeyStore.getInstance(rpaConfiguration.getJksConfig().getKeyStoreType());
             keystore.load(Files.newInputStream(
                             Paths.get(rpaConfiguration.getJksConfig().getKeyStorePath())),
@@ -19,7 +25,7 @@ public class JKSKeyRetriever implements KeyRetriever {
                     rpaConfiguration.getJksConfig().getKeyPassword().toCharArray()
             );
         } catch (Exception e) {
-            throw new RuntimeException("Exception during key generation");
+            throw new RuntimeException("Exception during key generation - " + e.getMessage());
         }
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
@@ -1,2 +1,25 @@
-package gov.nist.oar.distrib.service.rpa;public class JKSKeyRetriever {
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.web.RPAConfiguration;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.Key;
+import java.security.KeyStore;
+
+public class JKSKeyRetriever implements KeyRetriever {
+    @Override
+    public Key getKey(RPAConfiguration rpaConfiguration)  {
+        try {
+            KeyStore keystore = KeyStore.getInstance(rpaConfiguration.getJksConfig().getKeyStoreType());
+            keystore.load(Files.newInputStream(
+                            Paths.get(rpaConfiguration.getJksConfig().getKeyStorePath())),
+                    rpaConfiguration.getJksConfig().getKeyStorePassword().toCharArray());
+            return keystore.getKey(
+                    rpaConfiguration.getJksConfig().getKeyAlias(),
+                    rpaConfiguration.getJksConfig().getKeyPassword().toCharArray()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Exception during key generation");
+        }
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/KeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/KeyRetriever.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa;public interface KeyRetriever {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/KeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/KeyRetriever.java
@@ -1,2 +1,19 @@
-package gov.nist.oar.distrib.service.rpa;public interface KeyRetriever {
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.web.RPAConfiguration;
+
+import java.security.Key;
+
+
+/**
+ * Interface to retrieve the private key.
+ */
+public interface KeyRetriever {
+
+    /**
+     * Get a private key.
+     *
+     * @param rpaConfiguration - the RPA configuration
+     */
+    Key getKey(RPAConfiguration rpaConfiguration);
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandlerService.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa;public class RPARequestHandlerService {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandlerService.java
@@ -1,2 +1,39 @@
-package gov.nist.oar.distrib.service.rpa;public class RPARequestHandlerService {
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
+import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
+import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
+
+
+/**
+ * Service interface for handling RPA request submissions by end users.
+ * When an end user submits a new request, a new record will be created.
+ */
+public interface RPARequestHandlerService {
+
+    /**
+     * Get information about a specific record.
+     * @param recordId  the identifier for the record.
+     *
+     * @return RecordWrapper -- the requested record wrapped within a "record" envelope.
+     */
+    RecordWrapper getRecord(String recordId);
+
+    /**
+     * Create a new record.
+     * @param userInfoWrapper  the information provided by the user.
+     *
+     * @return RecordWrapper -- the newly created record wrapped within a "record" envelope.
+     */
+    RecordWrapper createRecord(UserInfoWrapper userInfoWrapper);
+
+    /**
+     * Update the status of a specific record.
+     * @param recordId  the identifier for the record.
+     * @param status  the new status.
+     *
+     * @return RecordStatus -- the updated status of the record.
+     */
+    RecordStatus updateRecord(String recordId, String status);
+
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
@@ -1,2 +1,24 @@
-package gov.nist.oar.distrib.service.rpa.model;public class EmailInfo {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailInfo {
+    @JsonProperty("recordId")
+    String recordId;
+    @JsonProperty("recipient")
+    String recipient;
+    @JsonProperty("subject")
+    String subject;
+    @JsonProperty("content")
+    String content;
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
@@ -2,6 +2,8 @@ package gov.nist.oar.distrib.service.rpa.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
@@ -48,5 +50,18 @@ public class EmailInfo {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonStr;
+        try {
+            jsonStr = mapper.writeValueAsString(this);
+        } catch (
+                JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonStr;
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
@@ -3,13 +3,9 @@ package gov.nist.oar.distrib.service.rpa.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class EmailInfo {
@@ -21,4 +17,36 @@ public class EmailInfo {
     String subject;
     @JsonProperty("content")
     String content;
+
+    public String getRecordId() {
+        return recordId;
+    }
+
+    public void setRecordId(String recordId) {
+        this.recordId = recordId;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfo.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class EmailInfo {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfoWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfoWrapper.java
@@ -2,12 +2,8 @@ package gov.nist.oar.distrib.service.rpa.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class EmailInfoWrapper {
@@ -16,4 +12,20 @@ public class EmailInfoWrapper {
 
     @JsonProperty("email")
     EmailInfo emailInfo;
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public EmailInfo getEmailInfo() {
+        return emailInfo;
+    }
+
+    public void setEmailInfo(EmailInfo emailInfo) {
+        this.emailInfo = emailInfo;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfoWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfoWrapper.java
@@ -1,9 +1,15 @@
 package gov.nist.oar.distrib.service.rpa.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class EmailInfoWrapper {
     @JsonProperty("timestamp")
     String timestamp;

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfoWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/EmailInfoWrapper.java
@@ -1,0 +1,13 @@
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class EmailInfoWrapper {
+    @JsonProperty("timestamp")
+    String timestamp;
+
+    @JsonProperty("email")
+    EmailInfo emailInfo;
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/Record.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/Record.java
@@ -5,13 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Setter
-@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Record {
@@ -21,6 +17,31 @@ public class Record {
     private String caseNum;
     @JsonProperty("userInfo")
     private UserInfo userInfo;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCaseNum() {
+        return caseNum;
+    }
+
+    public void setCaseNum(String caseNum) {
+        this.caseNum = caseNum;
+    }
+
+    public UserInfo getUserInfo() {
+        return userInfo;
+    }
+
+    public void setUserInfo(UserInfo userInfo) {
+        this.userInfo = userInfo;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/Record.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/Record.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class Record {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/Record.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/Record.java
@@ -1,2 +1,37 @@
-package gov.nist.oar.distrib.service.rpa.model;public class Record {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Record {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("caseNum")
+    private String caseNum;
+    @JsonProperty("userInfo")
+    private UserInfo userInfo;
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonStr;
+        try {
+            jsonStr = mapper.writeValueAsString(this);
+        } catch (
+                JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonStr;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordPatch.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordPatch.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class RecordPatch {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordPatch.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordPatch.java
@@ -1,2 +1,23 @@
-package gov.nist.oar.distrib.service.rpa.model;public class RecordPatch {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordPatch {
+    @JsonProperty("Approval_Status__c")
+    String approvalStatus;
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordPatch.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordPatch.java
@@ -3,18 +3,22 @@ package gov.nist.oar.distrib.service.rpa.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Setter
-@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class RecordPatch {
     @JsonProperty("Approval_Status__c")
     String approvalStatus;
+
+    public String getApprovalStatus() {
+        return approvalStatus;
+    }
+
+    public void setApprovalStatus(String approvalStatus) {
+        this.approvalStatus = approvalStatus;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordStatus.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordStatus.java
@@ -2,12 +2,8 @@ package gov.nist.oar.distrib.service.rpa.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class RecordStatus {
@@ -15,4 +11,20 @@ public class RecordStatus {
     String recordId;
     @JsonProperty("approvalStatus")
     String approvalStatus;
+
+    public String getRecordId() {
+        return recordId;
+    }
+
+    public void setRecordId(String recordId) {
+        this.recordId = recordId;
+    }
+
+    public String getApprovalStatus() {
+        return approvalStatus;
+    }
+
+    public void setApprovalStatus(String approvalStatus) {
+        this.approvalStatus = approvalStatus;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordStatus.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordStatus.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class RecordStatus {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordStatus.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordStatus.java
@@ -1,2 +1,18 @@
-package gov.nist.oar.distrib.service.rpa.model;public class RecordStatus {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordStatus {
+    @JsonProperty("recordId")
+    String recordId;
+    @JsonProperty("approvalStatus")
+    String approvalStatus;
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordWrapper.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class RecordWrapper {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordWrapper.java
@@ -1,2 +1,31 @@
-package gov.nist.oar.distrib.service.rpa.model;public class RecordWrapper {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordWrapper {
+    @JsonProperty("record")
+    Record record;
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonStr;
+        try {
+            jsonStr = mapper.writeValueAsString(this);
+        } catch (
+                JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonStr;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/RecordWrapper.java
@@ -4,17 +4,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class RecordWrapper {
     @JsonProperty("record")
     Record record;
+
+    public Record getRecord() {
+        return record;
+    }
+
+    public void setRecord(Record record) {
+        this.record = record;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/SalesforceToken.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/SalesforceToken.java
@@ -1,0 +1,20 @@
+package gov.nist.oar.distrib.service.rpa;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SalesforceToken {
+    @JsonProperty("access_token")
+    String accessToken;
+    @JsonProperty("instance_url")
+    String instanceUrl;
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/SalesforceToken.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/SalesforceToken.java
@@ -1,4 +1,4 @@
-package gov.nist.oar.distrib.service.rpa;
+package gov.nist.oar.distrib.service.rpa.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/SalesforceToken.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/SalesforceToken.java
@@ -3,13 +3,9 @@ package gov.nist.oar.distrib.service.rpa.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class SalesforceToken {
@@ -17,4 +13,20 @@ public class SalesforceToken {
     String accessToken;
     @JsonProperty("instance_url")
     String instanceUrl;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getInstanceUrl() {
+        return instanceUrl;
+    }
+
+    public void setInstanceUrl(String instanceUrl) {
+        this.instanceUrl = instanceUrl;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfo.java
@@ -3,13 +3,9 @@ package gov.nist.oar.distrib.service.rpa.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserInfo {
@@ -31,4 +27,76 @@ public class UserInfo {
     private String subject;
     @JsonProperty("description")
     private String description;
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getReceiveEmails() {
+        return receiveEmails;
+    }
+
+    public void setReceiveEmails(String receiveEmails) {
+        this.receiveEmails = receiveEmails;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getApprovalStatus() {
+        return approvalStatus;
+    }
+
+    public void setApprovalStatus(String approvalStatus) {
+        this.approvalStatus = approvalStatus;
+    }
+
+    public String getProductTitle() {
+        return productTitle;
+    }
+
+    public void setProductTitle(String productTitle) {
+        this.productTitle = productTitle;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfo.java
@@ -1,2 +1,34 @@
-package gov.nist.oar.distrib.service.rpa.model;public class UserInfo {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfo {
+    @JsonProperty("fullName")
+    private String fullName;
+    @JsonProperty("organization")
+    private String organization;
+    @JsonProperty("email")
+    private String email;
+    @JsonProperty("receiveEmails")
+    private String receiveEmails;
+    @JsonProperty("country")
+    private String country;
+    @JsonProperty("approvalStatus")
+    private String approvalStatus;
+    @JsonProperty("productTitle")
+    private String productTitle;
+    @JsonProperty("subject")
+    private String subject;
+    @JsonProperty("description")
+    private String description;
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfo.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfo.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class UserInfo {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfoWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfoWrapper.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.service.rpa.model;public class UserInfoWrapper {
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfoWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfoWrapper.java
@@ -1,2 +1,16 @@
-package gov.nist.oar.distrib.service.rpa.model;public class UserInfoWrapper {
+package gov.nist.oar.distrib.service.rpa.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoWrapper {
+    @JsonProperty("userInfo")
+    UserInfo userInfo;
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfoWrapper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/model/UserInfoWrapper.java
@@ -2,15 +2,19 @@ package gov.nist.oar.distrib.service.rpa.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserInfoWrapper {
     @JsonProperty("userInfo")
     UserInfo userInfo;
+
+    public UserInfo getUserInfo() {
+        return userInfo;
+    }
+
+    public void setUserInfo(UserInfo userInfo) {
+        this.userInfo = userInfo;
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
@@ -406,6 +406,8 @@ public class NISTCacheManagerConfig {
                 if (rolenms.contains("small")) roles |= PDRCacheRoles.ROLE_SMALL_OBJECTS;
                 if (rolenms.contains("large")) roles |= PDRCacheRoles.ROLE_LARGE_OBJECTS;
                 if (rolenms.contains("old")) roles |= PDRCacheRoles.ROLE_OLD_VERSIONS;
+                if (rolenms.contains("restricted")) roles |= PDRCacheRoles.ROLE_RESTRICTED_DATA;
+                if (rolenms.contains("old-restricted")) roles |= PDRCacheRoles.ROLE_OLD_RESTRICTED_DATA;
             }
 
             vc = (new VolumeConfig(cfg.getStatusCode())).withDeletionStrategy(cfg.createDeletionStrategy())

--- a/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
@@ -13,6 +13,10 @@ package gov.nist.oar.distrib.web;
 
 import gov.nist.oar.distrib.BagStorage;
 import gov.nist.oar.distrib.service.*;
+import gov.nist.oar.distrib.service.rpa.DefaultKeyRetriever;
+import gov.nist.oar.distrib.service.rpa.DefaultRPARequestHandlerService;
+import gov.nist.oar.distrib.service.rpa.KeyRetriever;
+import gov.nist.oar.distrib.service.rpa.RPARequestHandlerService;
 import gov.nist.oar.distrib.storage.AWSS3LongTermStorage;
 import gov.nist.oar.distrib.storage.FilesystemLongTermStorage;
 import io.swagger.v3.oas.models.Components;
@@ -277,13 +281,37 @@ public class NISTDistribServiceConfig {
     }
 
     /**
-     * the service implementation to use for restricted data access
+     * the service implementation to use for restricted data access caching service
      */
     @Bean
     public RPACachingService getRestrictedDataCachingService(CacheManagerProvider cacheManagerProvider)
             throws ConfigurationException {
         return new RPACachingService(cacheManagerProvider.getPDRCacheManager());
     }
+
+    @Bean
+    @ConfigurationProperties("distrib.rpa")
+    public RPAConfiguration getRPAConfiguration() throws ConfigurationException {
+        // this will have config properties injected into it
+        return new RPAConfiguration();
+    }
+
+    /**
+     * the implementation to use for the private key retriever
+     */
+    @Bean
+    public KeyRetriever getKeyRetriever() {
+        return new DefaultKeyRetriever();
+    }
+
+    /**
+     * the service implementation to use for RPARequestHandlerService
+     */
+    @Bean
+    public RPARequestHandlerService getRPARequestHandlerService(RPAConfiguration rpaConfiguration, KeyRetriever keyRetriever) {
+        return new DefaultRPARequestHandlerService(rpaConfiguration, keyRetriever);
+    }
+
     /**
      * configure MVC model, including setting CORS support and semicolon in URLs.
      * <p>

--- a/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
@@ -12,6 +12,7 @@
 package gov.nist.oar.distrib.web;
 
 import gov.nist.oar.distrib.BagStorage;
+import gov.nist.oar.distrib.service.*;
 import gov.nist.oar.distrib.storage.AWSS3LongTermStorage;
 import gov.nist.oar.distrib.storage.FilesystemLongTermStorage;
 import io.swagger.v3.oas.models.Components;
@@ -19,12 +20,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
-import gov.nist.oar.distrib.service.FileDownloadService;
-import gov.nist.oar.distrib.service.NerdmDrivenFromBagFileDownloadService;
-import gov.nist.oar.distrib.service.PreservationBagService;
-import gov.nist.oar.distrib.service.DefaultPreservationBagService;
-import gov.nist.oar.distrib.service.DataPackagingService;
-import gov.nist.oar.distrib.service.DefaultDataPackagingService;
 import gov.nist.oar.distrib.cachemgr.pdr.PDRCacheManager;
 
 import java.io.InputStream;
@@ -281,6 +276,14 @@ public class NISTDistribServiceConfig {
         return new CacheManagerProvider(config, bagstor, s3client);
     }
 
+    /**
+     * the service implementation to use for restricted data access
+     */
+    @Bean
+    public RPACachingService getRestrictedDataCachingService(CacheManagerProvider cacheManagerProvider)
+            throws ConfigurationException {
+        return new RPACachingService(cacheManagerProvider.getPDRCacheManager());
+    }
     /**
      * configure MVC model, including setting CORS support and semicolon in URLs.
      * <p>

--- a/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
@@ -13,10 +13,7 @@ package gov.nist.oar.distrib.web;
 
 import gov.nist.oar.distrib.BagStorage;
 import gov.nist.oar.distrib.service.*;
-import gov.nist.oar.distrib.service.rpa.DefaultKeyRetriever;
-import gov.nist.oar.distrib.service.rpa.DefaultRPARequestHandlerService;
-import gov.nist.oar.distrib.service.rpa.KeyRetriever;
-import gov.nist.oar.distrib.service.rpa.RPARequestHandlerService;
+import gov.nist.oar.distrib.service.rpa.*;
 import gov.nist.oar.distrib.storage.AWSS3LongTermStorage;
 import gov.nist.oar.distrib.storage.FilesystemLongTermStorage;
 import io.swagger.v3.oas.models.Components;
@@ -301,7 +298,7 @@ public class NISTDistribServiceConfig {
      */
     @Bean
     public KeyRetriever getKeyRetriever() {
-        return new DefaultKeyRetriever();
+        return new JKSKeyRetriever();
     }
 
     /**

--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.NonFinal;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -28,6 +26,8 @@ public class RPAConfiguration {
     private String salesforceInstanceUrl = null;
     @JsonProperty("pdrCachingUrl")
     private String pdrCachingUrl = null;
+    @JsonProperty("datacartUrl")
+    private String datacartUrl = null;
     @JsonProperty("salesforceEndpoints")
     private Map<String, String> salesforceEndpoints = null;
     @JsonProperty("jksConfig")
@@ -72,6 +72,14 @@ public class RPAConfiguration {
 
     public void setPdrCachingUrl(String pdrCachingUrl) {
         this.pdrCachingUrl = pdrCachingUrl;
+    }
+
+    public String getDatacartUrl() {
+        return datacartUrl;
+    }
+
+    public void setDatacartUrl(String datacartUrl) {
+        this.datacartUrl = datacartUrl;
     }
 
     public Map<String, String> getSalesforceEndpoints() {

--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -1,5 +1,9 @@
 package gov.nist.oar.distrib.web;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,12 +18,19 @@ import java.util.Map;
 public class RPAConfiguration {
 
 
+    @JsonProperty("salesforceJwt")
     private SalesforceJwt salesforceJwt = null;
+    @JsonProperty("emailTemplates")
     private Map<String, EmailTemplate> emailTemplates = null;
+    @JsonProperty("approvers")
     private Map<String, Approver> approvers = null;
+    @JsonProperty("salesforceInstanceUrl")
     private String salesforceInstanceUrl = null;
+    @JsonProperty("pdrCachingUrl")
     private String pdrCachingUrl = null;
+    @JsonProperty("salesforceEndpoints")
     private Map<String, String> salesforceEndpoints = null;
+    @JsonProperty("jksConfig")
     private JksConfig jksConfig = null;
 
 
@@ -79,42 +90,163 @@ public class RPAConfiguration {
         this.jksConfig = jksConfig;
     }
 
-    @Getter
-    @Setter
     @NoArgsConstructor
     public static class SalesforceJwt {
+        @JsonProperty("clientId")
+        @JsonIgnore
         String clientId;
+        @JsonProperty("subject")
         String subject;
+        @JsonProperty("audience")
         String audience;
+        @JsonProperty("expirationInMinutes")
         Integer expirationInMinutes;
+        @JsonProperty("grantType")
         String grantType;
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public void setClientId(String clientId) {
+            this.clientId = clientId;
+        }
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public void setSubject(String subject) {
+            this.subject = subject;
+        }
+
+        public String getAudience() {
+            return audience;
+        }
+
+        public void setAudience(String audience) {
+            this.audience = audience;
+        }
+
+        public Integer getExpirationInMinutes() {
+            return expirationInMinutes;
+        }
+
+        public void setExpirationInMinutes(Integer expirationInMinutes) {
+            this.expirationInMinutes = expirationInMinutes;
+        }
+
+        public String getGrantType() {
+            return grantType;
+        }
+
+        public void setGrantType(String grantType) {
+            this.grantType = grantType;
+        }
     }
 
-    @Getter
-    @Setter
     @NoArgsConstructor
     public static class JksConfig {
+        @JsonProperty("keyStoreType")
         String keyStoreType;
+        @JsonProperty("keyStorePath")
         String keyStorePath;
+        @JsonProperty("keyStorePassword")
+        @JsonIgnore
         String keyStorePassword;
+        @JsonProperty("keyAlias")
         String keyAlias;
+        @JsonProperty("keyPassword")
+        @JsonIgnore
         String keyPassword;
+
+        public String getKeyStoreType() {
+            return keyStoreType;
+        }
+
+        public void setKeyStoreType(String keyStoreType) {
+            this.keyStoreType = keyStoreType;
+        }
+
+        public String getKeyStorePath() {
+            return keyStorePath;
+        }
+
+        public void setKeyStorePath(String keyStorePath) {
+            this.keyStorePath = keyStorePath;
+        }
+
+        public String getKeyStorePassword() {
+            return keyStorePassword;
+        }
+
+        public void setKeyStorePassword(String keyStorePassword) {
+            this.keyStorePassword = keyStorePassword;
+        }
+
+        public String getKeyAlias() {
+            return keyAlias;
+        }
+
+        public void setKeyAlias(String keyAlias) {
+            this.keyAlias = keyAlias;
+        }
+
+        public String getKeyPassword() {
+            return keyPassword;
+        }
+
+        public void setKeyPassword(String keyPassword) {
+            this.keyPassword = keyPassword;
+        }
     }
 
-    @Getter
-    @Setter
     @NoArgsConstructor
     public static class EmailTemplate {
+        @JsonProperty("subject")
         private String subject;
+        @JsonProperty("content")
         private String content;
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public void setSubject(String subject) {
+            this.subject = subject;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
     }
 
-    @Getter
-    @Setter
     @NoArgsConstructor
     public static class Approver {
+        @JsonProperty("name")
         private String name;
+        @JsonProperty("email")
         private String email;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
     }
 
     public EmailTemplate getEndUserConfirmationEmail() {
@@ -131,5 +263,18 @@ public class RPAConfiguration {
 
     public EmailTemplate getEndUserDeclinedEmail() {
         return this.getEmailTemplates().get("declined-user");
+    }
+
+    @Override
+    public String toString() {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonStr;
+        try {
+            jsonStr = mapper.writeValueAsString(this);
+        } catch (
+                JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonStr;
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.web;public class RPAConfiguration {
+}

--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -1,2 +1,135 @@
-package gov.nist.oar.distrib.web;public class RPAConfiguration {
+package gov.nist.oar.distrib.web;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.NonFinal;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+import java.util.Map;
+
+@NonFinal
+@Validated
+@ConfigurationProperties("distrib.rpa")
+public class RPAConfiguration {
+
+
+    private SalesforceJwt salesforceJwt = null;
+    private Map<String, EmailTemplate> emailTemplates = null;
+    private Map<String, Approver> approvers = null;
+    private String salesforceInstanceUrl = null;
+    private String pdrCachingUrl = null;
+    private Map<String, String> salesforceEndpoints = null;
+    private JksConfig jksConfig = null;
+
+
+    public SalesforceJwt getSalesforceJwt() {
+        return salesforceJwt;
+    }
+
+    public void setSalesforceJwt(SalesforceJwt salesforceJwt) {
+        this.salesforceJwt = salesforceJwt;
+    }
+
+    public Map<String, EmailTemplate> getEmailTemplates() {
+        return emailTemplates;
+    }
+
+    public void setEmailTemplates(Map<String, EmailTemplate> emailTemplates) {
+        this.emailTemplates = emailTemplates;
+    }
+
+    public Map<String, Approver> getApprovers() {
+        return approvers;
+    }
+
+    public void setApprovers(Map<String, Approver> approvers) {
+        this.approvers = approvers;
+    }
+
+    public String getSalesforceInstanceUrl() {
+        return salesforceInstanceUrl;
+    }
+
+    public void setSalesforceInstanceUrl(String salesforceInstanceUrl) {
+        this.salesforceInstanceUrl = salesforceInstanceUrl;
+    }
+
+    public String getPdrCachingUrl() {
+        return pdrCachingUrl;
+    }
+
+    public void setPdrCachingUrl(String pdrCachingUrl) {
+        this.pdrCachingUrl = pdrCachingUrl;
+    }
+
+    public Map<String, String> getSalesforceEndpoints() {
+        return salesforceEndpoints;
+    }
+
+    public void setSalesforceEndpoints(Map<String, String> salesforceEndpoints) {
+        this.salesforceEndpoints = salesforceEndpoints;
+    }
+
+    public JksConfig getJksConfig() {
+        return jksConfig;
+    }
+
+    public void setJksConfig(JksConfig jksConfig) {
+        this.jksConfig = jksConfig;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class SalesforceJwt {
+        String clientId;
+        String subject;
+        String audience;
+        Integer expirationInMinutes;
+        String grantType;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class JksConfig {
+        String keyStoreType;
+        String keyStorePath;
+        String keyStorePassword;
+        String keyAlias;
+        String keyPassword;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class EmailTemplate {
+        private String subject;
+        private String content;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Approver {
+        private String name;
+        private String email;
+    }
+
+    public EmailTemplate getEndUserConfirmationEmail() {
+        return this.getEmailTemplates().get("ack-user");
+    }
+
+    public EmailTemplate getSMEApprovalEmail() {
+        return this.getEmailTemplates().get("to-sme");
+    }
+
+    public EmailTemplate getEndUserApprovedEmail() {
+        return this.getEmailTemplates().get("approved-user");
+    }
+
+    public EmailTemplate getEndUserDeclinedEmail() {
+        return this.getEmailTemplates().get("declined-user");
+    }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/RPADataCachingController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPADataCachingController.java
@@ -1,0 +1,59 @@
+package gov.nist.oar.distrib.web;
+
+import gov.nist.oar.distrib.ResourceNotFoundException;
+import gov.nist.oar.distrib.StorageVolumeException;
+import gov.nist.oar.distrib.cachemgr.CacheManagementException;
+import gov.nist.oar.distrib.service.RPACachingService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Set;
+
+@RestController
+@Tag(name = "Cache RPA Datasets", description = "Cache Restricted Public Access data in a dedicated cache space and generate temporary URL for the cached data.")
+@RequestMapping(value = "/ds/restricted")
+public class RPADataCachingController {
+
+    @Value("${distrib.baseurl}")
+    String baseURL;
+
+    Logger logger = LoggerFactory.getLogger(RPADataCachingController.class);
+
+    @Autowired
+    RPACachingService restrictedSrvc;
+
+    @PutMapping(value = "/{dsid}")
+    public String cacheDataset(
+            @PathVariable("dsid") String dsid,
+            @RequestParam(name = "version", defaultValue = "") String version)
+            throws CacheManagementException, ResourceNotFoundException, StorageVolumeException {
+
+        logger.info("dsid=" + dsid);
+        String temporaryURL = restrictedSrvc.cacheAndGenerateTemporaryUrl(dsid, version);
+        return temporaryURL;
+    }
+
+    @GetMapping(value = "/{randomId}")
+    public Map<String, Object> retrieveMetadata(@PathVariable("randomId") String randomId)
+            throws CacheManagementException {
+
+        logger.info("randomId=" + randomId);
+        Map<String, Object> metadata = restrictedSrvc.retrieveMetadata(randomId);
+        return metadata;
+    }
+
+    // utility function to log urls
+    private void logUrls(String dsid, Set<String> urls) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("List of temporary URLs for dataset_id=").append(dsid + "\n");
+        urls.forEach(url -> {
+            sb.append(url + "\n");
+        });
+        logger.info(sb.toString());
+    }
+}

--- a/src/main/java/gov/nist/oar/distrib/web/RPADataCachingController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPADataCachingController.java
@@ -34,8 +34,8 @@ public class RPADataCachingController {
             throws CacheManagementException, ResourceNotFoundException, StorageVolumeException {
 
         logger.info("dsid=" + dsid);
-        String temporaryURL = restrictedSrvc.cacheAndGenerateTemporaryUrl(dsid, version);
-        return temporaryURL;
+        String randomId = restrictedSrvc.cacheAndGenerateRandomId(dsid, version);
+        return randomId;
     }
 
     @GetMapping(value = "/{randomId}")

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
         name = "Restricted Public Access Request Handler API",
         description = "These endpoints will handle end user request to download data under restricted public access."
 )
-@RequestMapping(value = "/rpa")
+@RequestMapping(value = "/ds/rpa")
 public class RPARequestHandlerController {
     @Autowired
     RPARequestHandlerService service;

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -38,7 +38,7 @@ public class RPARequestHandlerController {
         return record;
     }
 
-    @PostMapping(value = "new/{id}", consumes = {"application/json"})
+    @PostMapping(consumes = {"application/json"})
     RecordWrapper createRecord(@RequestBody UserInfoWrapper userInfoWrapper) {
         LOGGER.info("Creating a new record...");
         RecordWrapper newRecord = service.createRecord(userInfoWrapper);

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -1,6 +1,6 @@
 package gov.nist.oar.distrib.web;
 
-import gov.nist.oar.distrib.service.rpa.DefaultRPARequestHandlerService;
+import gov.nist.oar.distrib.service.rpa.RPARequestHandlerService;
 import gov.nist.oar.distrib.service.rpa.model.RecordPatch;
 import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
 import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,7 +20,8 @@ import org.springframework.web.bind.annotation.*;
 )
 @RequestMapping(value = "/rpa")
 public class RPARequestHandlerController {
-    private final DefaultRPARequestHandlerService service;
+    @Autowired
+    RPARequestHandlerService service;
     private final static Logger LOGGER = LoggerFactory.getLogger(RPARequestHandlerController.class);
 
     @GetMapping("test")

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.web;public class RPARequestHandlerController {
+}

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -1,2 +1,52 @@
-package gov.nist.oar.distrib.web;public class RPARequestHandlerController {
+package gov.nist.oar.distrib.web;
+
+import gov.nist.oar.distrib.service.rpa.DefaultRPARequestHandlerService;
+import gov.nist.oar.distrib.service.rpa.model.RecordPatch;
+import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
+import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
+import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(
+        name = "Restricted Public Access Request Handler API",
+        description = "These endpoints will handle end user request to download data under restricted public access."
+)
+@RequestMapping(value = "/rpa")
+public class RPARequestHandlerController {
+    private final DefaultRPARequestHandlerService service;
+    private final static Logger LOGGER = LoggerFactory.getLogger(RPARequestHandlerController.class);
+
+    @GetMapping("test")
+    String testConnectionToSalesforceAPIs() {
+        LOGGER.info("Testing connection to Salesforce APIs...");
+        return "Salesforce API is available.";
+    }
+
+    @GetMapping(value = "{id}")
+    RecordWrapper getRecord(@PathVariable String id) {
+        LOGGER.info("Getting information about record with ID = " + id);
+        RecordWrapper record = service.getRecord(id);
+        LOGGER.debug("RECORD=" + record.toString());
+        return record;
+    }
+
+    @PostMapping(value = "new/{id}", consumes = {"application/json"})
+    RecordWrapper createRecord(@RequestBody UserInfoWrapper userInfoWrapper) {
+        LOGGER.info("Creating a new record...");
+        RecordWrapper newRecord = service.createRecord(userInfoWrapper);
+        LOGGER.debug("RECORD=" + newRecord.toString());
+        return newRecord;
+    }
+
+    @PatchMapping(value = "{id}", consumes = "application/json")
+    public RecordStatus updateRecord(@PathVariable String id, @RequestBody RecordPatch patch) {
+        LOGGER.info("Updating approval status of record with ID = " + id);
+        return service.updateRecord(patch.getApprovalStatus(), id);
+    }
 }

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManagerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManagerTest.java
@@ -138,7 +138,7 @@ public class PDRCacheManagerTest {
         assertTrue(! mgr.isCached("mds1491/trial1.json"));
         assertTrue(! mgr.isCached("mds1491/trial2.json"));
         assertTrue(! mgr.isCached("mds1491/trial3/trial3a.json"));
-        mgr.cacheDataset("mds1491", null, true);
+        mgr.cacheDataset("mds1491", null, true, 0 , null);
         assertTrue(mgr.isCached("mds1491/trial1.json"));
         assertTrue(mgr.isCached("mds1491/trial2.json"));
         assertTrue(mgr.isCached("mds1491/trial3/trial3a.json"));
@@ -151,7 +151,7 @@ public class PDRCacheManagerTest {
         mgr.uncache("mds1491/trial1.json");
         assertTrue(! mgr.isCached("mds1491/trial1.json"));
         assertTrue(mgr.isCached("mds1491/trial2.json"));
-        mgr.cacheDataset("mds1491", null, false);
+        mgr.cacheDataset("mds1491", null, false, 0 , null);
         assertTrue(mgr.isCached("mds1491/trial1.json"));
         assertTrue(mgr.isCached("mds1491/trial2.json"));
         co = mgr.findObject("mds1491/trial2.json");
@@ -162,10 +162,10 @@ public class PDRCacheManagerTest {
     public void cacheAllTestData()
         throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
     {
-        mgr.cacheDataset("mds1491", null, true);
-        mgr.cacheDataset("mds1491", "1", true);
-        mgr.cacheDataset("mds1491", "1.1.0", true);
-        mgr.cacheDataset("67C783D4BA814C8EE05324570681708A1899", null, true);
+        mgr.cacheDataset("mds1491", null, true, 0 , null);
+        mgr.cacheDataset("mds1491", "1", true, 0 , null);
+        mgr.cacheDataset("mds1491", "1.1.0", true, 0 , null);
+        mgr.cacheDataset("67C783D4BA814C8EE05324570681708A1899", null, true, 0 , null);
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorerTest.java
@@ -250,7 +250,7 @@ public class PDRDatasetRestorerTest {
         assertTrue(! cache.isCached("mds1491/trial2.json#1"));
         assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#1"));
 
-        Set<String> cached = rstr.cacheDataset("mds1491", null, cache, true);
+        Set<String> cached = rstr.cacheDataset("mds1491", null, cache, true, 0 , null);
         assertTrue(cached.contains("trial1.json"));
         assertTrue(cached.contains("trial2.json"));
         assertTrue(cached.contains("trial3/trial3a.json"));
@@ -266,7 +266,7 @@ public class PDRDatasetRestorerTest {
         assertTrue(! cache.isCached("mds1491/trial2.json#1"));
         assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#1"));
 
-        cached = rstr.cacheDataset("mds1491", "1", cache, true);
+        cached = rstr.cacheDataset("mds1491", "1", cache, true, 0 , null);
         assertTrue(cached.contains("trial1.json"));
         assertTrue(cached.contains("trial2.json"));
         assertTrue(cached.contains("trial3/trial3a.json"));
@@ -282,7 +282,7 @@ public class PDRDatasetRestorerTest {
         assertTrue(cache.isCached("mds1491/trial2.json#1"));
         assertTrue(cache.isCached("mds1491/trial3/trial3a.json#1"));
 
-        cached = rstr.cacheDataset("mds1491", "1.1.0", cache, true);
+        cached = rstr.cacheDataset("mds1491", "1.1.0", cache, true, 0 , null);
         assertTrue(cached.contains("trial1.json"));
         assertTrue(cached.contains("trial2.json"));
         assertTrue(cached.contains("trial3/trial3a.json"));
@@ -300,7 +300,7 @@ public class PDRDatasetRestorerTest {
 
         assertTrue(! cache.isCached("67C783D4BA814C8EE05324570681708A1899/NMRRVocab20171102.rdf"));
         assertTrue(! cache.isCached("67C783D4BA814C8EE05324570681708A1899/NMRRVocab20171102.rdf.sha256"));
-        cached = rstr.cacheDataset("67C783D4BA814C8EE05324570681708A1899", null, cache, true);
+        cached = rstr.cacheDataset("67C783D4BA814C8EE05324570681708A1899", null, cache, true, 0 , null);
         assertEquals(2, cached.size());
         assertTrue(cache.isCached("67C783D4BA814C8EE05324570681708A1899/NMRRVocab20171102.rdf"));
         assertTrue(! cache.isCached("67C783D4BA814C8EE05324570681708A1899/NMRRVocab20171102.rdf.sha256"));

--- a/src/test/java/gov/nist/oar/distrib/web/CacheManagementControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/CacheManagementControllerTest.java
@@ -153,7 +153,7 @@ public class CacheManagementControllerTest {
     public void setUp()
         throws CacheManagementException, StorageVolumeException, ResourceNotFoundException, ConfigurationException
     {
-        provider.getPDRCacheManager().cacheDataset("mds1491", null, true);
+        provider.getPDRCacheManager().cacheDataset("mds1491", null, true, 0 , null);
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/web/NISTCacheManagerConfigTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/NISTCacheManagerConfigTest.java
@@ -102,6 +102,38 @@ public class NISTCacheManagerConfigTest {
         vcfg.setDeletionStrategy(strat);
         vols.add(vcfg);
 
+        vcfg = new NISTCacheManagerConfig.CacheVolumeConfig();
+        vcfg.setCapacity(5000L);
+        vdir = new File(rootdir, "vols/topsecret");
+        vdir.mkdirs();
+        vcfg.setLocation("file://" + vdir.toString());
+        vcfg.setStatus("update");
+        roles = new ArrayList<>();
+        roles.add("restricted");
+        vcfg.setRoles(roles);
+        vcfg.setRedirectBase("http://data.nist.gov/cache/topsecret");
+        vcfg.setName("topsecret");
+        strat = new HashMap<>();
+        strat.put("type", "bigoldest");
+        vcfg.setDeletionStrategy(strat);
+        vols.add(vcfg);
+
+        vcfg = new NISTCacheManagerConfig.CacheVolumeConfig();
+        vcfg.setCapacity(5000L);
+        vdir = new File(rootdir, "vols/oldtopsecret");
+        vdir.mkdirs();
+        vcfg.setLocation("file://" + vdir.toString());
+        vcfg.setStatus("update");
+        roles = new ArrayList<>();
+        roles.add("old-restricted");
+        vcfg.setRoles(roles);
+        vcfg.setRedirectBase("http://data.nist.gov/cache/oldtopsecret");
+        vcfg.setName("oldtopsecret");
+        strat = new HashMap<>();
+        strat.put("type", "bigoldest");
+        vcfg.setDeletionStrategy(strat);
+        vols.add(vcfg);
+
         cfg.setVolumes(vols);
     }
 
@@ -178,6 +210,14 @@ public class NISTCacheManagerConfigTest {
         cvi = db.getVolumeInfo("pratt");
         assertEquals(3000L, cvi.getLong("capacity"));
         assertEquals(PDRCacheRoles.ROLE_OLD_VERSIONS|PDRCacheRoles.ROLE_SMALL_OBJECTS, cvi.getInt("roles"));
+
+        cvi = db.getVolumeInfo("topsecret");
+        assertEquals(5000L, cvi.getLong("capacity"));
+        assertEquals(PDRCacheRoles.ROLE_RESTRICTED_DATA, cvi.getInt("roles"));
+
+        cvi = db.getVolumeInfo("oldtopsecret");
+        assertEquals(5000L, cvi.getLong("capacity"));
+        assertEquals(PDRCacheRoles.ROLE_OLD_RESTRICTED_DATA, cvi.getInt("roles"));
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/web/RPADataCachingControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPADataCachingControllerTest.java
@@ -72,7 +72,7 @@ public class RPADataCachingControllerTest {
         ResponseEntity<Map<String, Object>> response = websvc.exchange(getBaseURL() + "/ds/restricted/" + randomId,
                 HttpMethod.GET, req, responseType);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
-        String metadata = resp.getBody();
-        assertEquals(metadata.length(),3 );
+        Map<String, Object> metadata = response.getBody();
+        assertEquals(metadata.size(),3 );
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/web/RPADataCachingControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPADataCachingControllerTest.java
@@ -1,0 +1,78 @@
+package gov.nist.oar.distrib.web;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = NISTDistribServiceConfig.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+})
+public class RPADataCachingControllerTest {
+
+    Logger logger = LoggerFactory.getLogger(RPADataCachingControllerTest.class);
+
+    @LocalServerPort
+    int port;
+
+    TestRestTemplate websvc = new TestRestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+
+    private String getBaseURL() {
+        return "http://localhost:" + port + "/od";
+    }
+
+    @Test
+    public void testCacheDataset() {
+        String dsid = "849E1CC6FBE2C4C7E053B3570681FE987034";
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/restricted/" + dsid,
+                HttpMethod.PUT, req, String.class);
+
+        String randomId = resp.getBody();
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertTrue(randomId.contains("https://data.nist.gov/pdr/datacart/restricted_datacart?id="));
+        assertEquals(
+                randomId.length(),
+                "https://data.nist.gov/pdr/datacart/restricted_datacart?id=".length() + 20
+        ); // random id len = 20
+    }
+
+    @Test
+    public void testRetrieveMetadata() {
+        String dsid = "849E1CC6FBE2C4C7E053B3570681FE987034";
+
+        // first we cache dataset
+        HttpEntity<String> req = new HttpEntity<String>(null, headers);
+        ResponseEntity<String> resp = websvc.exchange(getBaseURL() + "/ds/restricted/" + dsid,
+                HttpMethod.PUT, req, String.class);
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        //get randomId
+        String randomId = resp.getBody();
+
+        // use randomId to fetch metadata
+        req = new HttpEntity<String>(null, headers);
+        ParameterizedTypeReference<Map<String, Object>> responseType =
+                new ParameterizedTypeReference<Map<String,Object>>() {};
+        ResponseEntity<Map<String, Object>> response = websvc.exchange(getBaseURL() + "/ds/restricted/" + randomId,
+                HttpMethod.GET, req, responseType);
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        String metadata = resp.getBody();
+        assertEquals(metadata.length(),3 );
+    }
+}

--- a/src/test/java/gov/nist/oar/distrib/web/RPADataCachingControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPADataCachingControllerTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 @SpringBootTest(classes = NISTDistribServiceConfig.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {
-})
+        "distrib.baseurl=http://localhost/od/ds" })
 public class RPADataCachingControllerTest {
 
     Logger logger = LoggerFactory.getLogger(RPADataCachingControllerTest.class);


### PR DESCRIPTION
## What?

I've added support for Restricted Public Access (RPA).

Related tickets: 
- [ODD-1033](http://mml.nist.gov:8080/browse/ODD-1033)
- [ODD-1035](http://mml.nist.gov:8080/browse/ODD-1035)
- [ODD-1037](http://mml.nist.gov:8080/browse/ODD-1037)
- [ODD-1078](http://mml.nist.gov:8080/browse/ODD-1078)

## Why?

These changes will allow the OAR Distribution Service to handle public data with restricted access. Examples of access restriction are signage of a waiver or acknowledgement of disclaimer.  When users want to download data that has restricted access, the data will be first stored in a temporary cache. A temporary URL will be generated for the users to download that data, not from its original source, but from the temporary cache.

## How?

This includes addition of 2 controllers; _RPADataCachingController_ for handling the caching process and retrieval of metadata. _RPARequestHandlerController_ for handling requests from user to download data with restricted access.
Endpoints on each controller:
- RPADataCachingController:
  - **PUT /od/ds/restricted/{dsid}**: used to temporarily cache the dataset with id _dsid_
  - **GET /od/ds/restricted/{randomId}**: used to retrieve metadata about a dataset given the _randomId_

- RPARequestHandlerController:
  - **GET /od/ds/rpa/test**: to test connection with Salesforce service
  - **GET /od/ds/rpa/{id}**: retrieves information about a specific record in Salesforce, given its _id_
  - **POST /od/ds/rpa**: creates a new record in Salesforce
  - **PATCH /od/ds/rpa/{id}**: changes the status of a specific record given its _id_
 
Each controller has a service injected into it that handles the business logic.

- _RPACachingService_: interacts with the cache manager and handles the caching of the data file(s). To support this change, a new cache volume dedicated to restricted access was added to the cache manager, and new caching roles (ROLE_RESTRICTED_DATA, ROLE_OLD_RESTRICTED_DATA) were created.

- _DefaultRPARequestHandlerService_: interacts with Salesforce service to create, retrieve, and update records. This service also handles authentication flow; before each operation, it retrieves a JWT access token to use with the request.

I've created an _RPAConfiguration_ class that contains configuration needed for the new request handler. This configuration is injected in _DefaultRPARequestHandlerService_. The actual configuration will be pulled form the Config Server (in [oar-config](https://github.com/usnistgov/oar-config/blob/feature/ODD-1041_add_rpd_config/oar-config-server/src/main/resources/config/oar-dist-service/oar-dist-service.yml)).

 
## Testing

Most tests were done using Postman. Unit tests are still a work in progress. They will be ready before release to production.
I've created a mock service using FastApi to mimic the Salesforce service (create/read/update/delete records, and send emails). This mock service be used to replace the Salesforce backend during unit tests.