### PR TITLE
cachemgr bug fix: don't allow spaces in (AWS) redirect urls

### DIFF
--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -1,28 +1,12 @@
-FROM openjdk:8-jdk-slim-stretch
+FROM ibmjava:8-sdk
 
 # a hack that gets around an installation problem with update-alternatives, openjdk-8-jdk-headless
 
 RUN mkdir -p /usr/share/man/man1
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y netcat-openbsd zip git less \
-                                            gnupg python python-pip python-virtualenv \
-                                            make gcc curl maven
-
-# ARG gosu_arch=
-# ENV GOSU_ARCH $gosu_arch
-# ENV GOSU_VERSION 1.10
-# RUN set -ex; [ -n "$GOSU_ARCH" ] || arch=$(uname -r | awk -F- '{print $NF}'); \
-#     wget -O /usr/local/bin/gosu \
-#    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH"; \
-#     wget -O /usr/local/bin/gosu.asc \
-# "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$GOSU_ARCH.asc";\
-#     export GNUPGHOME="$(mktemp -d)"; \
-#     gpg --keyserver ha.pool.sks-keyservers.net \
-#          --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-#     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-#     sleep 1; rm -r /usr/local/bin/gosu.asc "$GNUPGHOME" || true; \
-#     chmod +x /usr/local/bin/gosu; \
-#     gosu nobody true
+                                            python2 curl maven
+RUN cd /usr/bin && ln -s python2 python
 
 # Create the user that build/test operations should run as.  Normally,
 # this is set to match identity information of the host user that is

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
@@ -437,7 +437,7 @@ public class AWSS3CacheVolume implements CacheVolume {
         if (baseurl == null)
             throw new UnsupportedOperationException("FilesystemCacheVolume: getRedirectFor not supported");
         try {
-            return new URL(baseurl + name);
+            return new URL(baseurl + name.replace(" ", "%20"));
         }
         catch (MalformedURLException ex) {
             throw new StorageVolumeException("Failed to form legal URL: "+ex.getMessage(), ex);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
@@ -317,7 +317,7 @@ public class FilesystemCacheVolume implements CacheVolume {
         if (baseurl == null)
             throw new UnsupportedOperationException("FilesystemCacheVolume: getRedirectFor not supported");
         try {
-            return new URL(baseurl + name);
+            return new URL(baseurl + name.replace(" ", "%20"));
         }
         catch (MalformedURLException ex) {
             throw new StorageVolumeException("Failed to form legal URL: "+ex.getMessage(), ex);

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
@@ -23,6 +23,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 import org.json.JSONObject;
 import org.json.JSONException;
@@ -402,5 +404,21 @@ public class AWSS3CacheVolumeTest {
         s3cv.saveAs(co, "gurn.txt");
         assertTrue(s3client.doesObjectExist(bucket, objname1));
         assertTrue(s3client.doesObjectExist(bucket, objname2));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRedirectForUnsupported()
+        throws StorageVolumeException, UnsupportedOperationException, IOException
+    {
+        s3cv.getRedirectFor("goober");
+    }
+
+    @Test
+    public void testRedirectFor()
+        throws StorageVolumeException, UnsupportedOperationException, IOException, MalformedURLException
+    {
+        s3cv = new AWSS3CacheVolume(bucket, "cach", s3client, "https://ex.org/");
+        assertEquals(new URL("https://ex.org/goober"), s3cv.getRedirectFor("goober"));
+        assertEquals(new URL("https://ex.org/i%20a/m%20groot"), s3cv.getRedirectFor("i a/m groot"));
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolumeTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolumeTest.java
@@ -28,6 +28,8 @@ import java.io.FileReader;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 import org.json.JSONObject;
 
@@ -203,5 +205,24 @@ public class FilesystemCacheVolumeTest {
 
         assertTrue(v.remove("goob"));
         assertFalse("Mistakenly believes non-existent object exists", v.exists("goob"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRedirectForUnsupported()
+        throws StorageVolumeException, UnsupportedOperationException, IOException
+    {
+        FilesystemCacheVolume v = makevol("root");
+        v.getRedirectFor("goober");
+    }
+
+    @Test
+    public void testRedirectFor()
+        throws StorageVolumeException, UnsupportedOperationException, IOException, MalformedURLException
+    {
+        String root = "root";
+        File rootdir = tempf.newFolder(root);
+        FilesystemCacheVolume v = new FilesystemCacheVolume(rootdir.toString(), root, "https://ex.org/");
+        assertEquals(new URL("https://ex.org/goober"), v.getRedirectFor("goober"));
+        assertEquals(new URL("https://ex.org/i%20a/m%20groot"), v.getRedirectFor("i a/m groot"));
     }
 }


### PR DESCRIPTION
A CacheManager can be configured to allow a request for a file located in an S3 cache to be redirected to a native S3 URL.  AWS does not support unencoded spaces in such URLs; otherwise, it respond with a 505 error.  Requests for an object having a name that included a space and which resides in an S3 cache can trigger this error, causing a download failure via the bundler.  This PR fixes this issue by ensuring that redirect URLs have their spaces encoded.  
