### PR TITLE
Restricted Public Access: fix authentication token parsing

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/web/JwtTokenValidator.java
+++ b/src/main/java/gov/nist/oar/distrib/web/JwtTokenValidator.java
@@ -80,7 +80,7 @@ public class JwtTokenValidator {
             tokenDetails.put("userFullname", userFullname);
             tokenDetails.put("userEmail", getClaimAsString(claims.get("userEmail"), "userEmail"));
             tokenDetails.put("expiry", getClaimAsString(claims.get("exp"), "exp"));
-            tokenDetails.put("user_id", getClaimAsString(claims.get("user_id"), "user_id"));
+            tokenDetails.put("user_id", getClaimAsString(claims.getSubject(), "user_id"));
 
             LOGGER.debug("Token successfully validated and details extracted.");
 

--- a/src/test/java/gov/nist/oar/distrib/web/JwtTokenValidatorTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/JwtTokenValidatorTest.java
@@ -94,12 +94,11 @@ public class JwtTokenValidatorTest {
 
         // Generate token without the "user_id" claim
         return Jwts.builder()
-                .setSubject("john.doe")
+                // .setSubject("john.doe") // Omit this claim to trigger the exception
                 .claim("userName", "John")
                 .claim("userLastName", "Doe")
                 .claim("userEmail", "john.doe@example.com")
                 .claim("exp", expirationTimeMillis)
-                // .claim("user_id", 12345) // Omit this claim to trigger the exception
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
@@ -120,7 +119,6 @@ public class JwtTokenValidatorTest {
                 .claim("userLastName", "Doe")
                 .claim("userEmail", "john.doe@example.com")
                 .claim("exp", expirationTimeMillis)
-                .claim("user_id", 12345)
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }


### PR DESCRIPTION
The part of the distribution service that processes approvals of restricted public access (RPA) requests requires an authentication token that was generated by our authentication service to be submitted as a credential.  The `JwtTokenValidator` class handles parsing and validating that token.  This PR fixes a parsing error that was causing it not to find the user identifier in the token; it now extracts value from the JWT "subject" claim.  
