### PR TITLE
Update Dockerfile Base Image to Resolve Build Issues on M1 Machines"

### DIFF
--- a/docker/build-test/Dockerfile
+++ b/docker/build-test/Dockerfile
@@ -1,12 +1,7 @@
-FROM ibmjava:8-sdk
-
-# a hack that gets around an installation problem with update-alternatives, openjdk-8-jdk-headless
+FROM eclipse-temurin:8
 
 RUN mkdir -p /usr/share/man/man1
-
-RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
-
-RUN apt-get update && apt-get upgrade -y && apt-get install -y netcat-openbsd zip git less \
+RUN apt-get update && apt-get install -y netcat-openbsd zip git less \
                                             python2 curl maven
 RUN cd /usr/bin && ln -s python2 python
 


### PR DESCRIPTION
#### Issue Faced:

- Initial Dockerfile with base image `ibmjava:8-sdk` resulted in an error indicating a platform mismatch.
- After setting `DOCKER_DEFAULT_PLATFORM=linux/amd64`, there was an error related to **http://archive.debian.org/debian stretch Release GPG** signatures being unverified.
- Even after trying to manually add the public keys, the problem persisted.
- Switching to another base image, `openjdk:8-jdk-slim-buster`, led to an error related to ca-certificates and Java.

#### Changes Made:

- Base Image Change: Changed the base image from `ibmjava:8-sdk` to `openjdk:8-jdk-slim-buster`. 
**Reason**: `ibmjava:8-sdk` was causing platform mismatch issues, and the public keys issue with Debian Stretch was unresolved.
- Installation of `ca-certificates-java`: After the base image was changed, an error related to ca-certificates and Java was observed. Added a new line to install ca-certificates-java:
`RUN apt-get update && apt-get install -y ca-certificates-java`
**Reason**: This resolves the error related to ca-certificates when using the `openjdk:8-jdk-slim-buster` base image.

#### Updated Dockerfile:

```bash
FROM openjdk:8-jdk-slim-buster
RUN mkdir -p /usr/share/man/man1
RUN apt-get update && apt-get install -y ca-certificates-java
RUN apt-get install -y netcat-openbsd zip git less python2 curl maven
RUN cd /usr/bin && ln -s python2 python

# Rest of file unchanged 
```

#### Further Changes:

- @RayPlante  mentioned using the `eclipse-temurin` base image for all Java containers. So, I switched to the `eclipse-temurin:8` base image for the Dockerfile. The Docker build was successful, both with `DOCKER_DEFAULT_PLATFORM=linux/amd64` set and unset. 
- After the switch to `eclipse-temurin:8`, there was no need to install `ca-certificates-java`.


#### Updated Dockerfile:

```bash
FROM eclipse-temurin:8
RUN mkdir -p /usr/share/man/man1
RUN apt-get update && apt-get install -y netcat-openbsd zip git less python2 curl maven
RUN cd /usr/bin && ln -s python2 python

# Rest of file unchanged 
```

#### Note:

The build was successful when executed from my home network, on both platforms. When I try the build from the campus network, I get the following error:

```bash
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.1.0.RELEASE/spring-boot-starter-parent-2.1.0.RELEASE.pom
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.commons:commons-lang3:jar -> version 3.12.0 vs 3.8.1 @ line 124, column 21
[FATAL] Non-resolvable parent POM for gov.nist.oar:oar-dist-service:1.0.0-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.1.0.RELEASE from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.1.0.RELEASE/spring-boot-starter-parent-2.1.0.RELEASE.pom and 'parent.relativePath' points at wrong local POM @ line 13, column 13
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project gov.nist.oar:oar-dist-service:1.0.0-SNAPSHOT (/app/dev/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for gov.nist.oar:oar-dist-service:1.0.0-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.1.0.RELEASE from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.1.0.RELEASE/spring-boot-starter-parent-2.1.0.RELEASE.pom and 'parent.relativePath' points at wrong local POM @ line 13, column 13: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```

I think this might due to campus firewall/proxy preventing access to Maven Central or not trusting its certificates.