### PR TITLE
Add CacheExpiryCheck for automated removal of expired cached data

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheck.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheck.java
@@ -1,0 +1,62 @@
+package gov.nist.oar.distrib.cachemgr;
+
+import gov.nist.oar.distrib.StorageVolumeException;
+
+/**
+ * Implements a cache object check to identify and remove objects that have been in the cache
+ * longer than a specified duration, specifically two weeks. This check helps in
+ * managing cache integrity by ensuring that stale or outdated data are removed
+ * from the cache.
+ */
+public class CacheExpiryCheck implements CacheObjectCheck {
+
+    private static final long TWO_WEEKS_MILLIS = 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
+    private StorageInventoryDB inventoryDB;
+
+    public CacheExpiryCheck(StorageInventoryDB inventoryDB) {
+        this.inventoryDB = inventoryDB;
+    }
+
+    /**
+     * Checks whether a cache object has expired based on its last modified time and removes it if expired.
+     * An object is considered expired if it has been in the cache for more than two weeks.
+     *
+     * @param co The CacheObject to be checked for expiry.
+     * @throws IntegrityException if the cache object's last modified time is unknown.
+     * @throws StorageVolumeException if there is an issue removing the expired object from the cache volume.
+     */
+    @Override
+    public void check(CacheObject co) throws IntegrityException, StorageVolumeException {
+        long currentTime = System.currentTimeMillis();
+        long objectLastModifiedTime = co.getLastModified();
+
+        // Throw an exception if the last modified time is unknown
+        if (objectLastModifiedTime == -1) {
+            throw new IntegrityException("Last modified time of cache object is unknown: " + co.name);
+        }
+
+        // If the cache object is expired, remove it from the cache
+        if ((currentTime - objectLastModifiedTime) > TWO_WEEKS_MILLIS) {
+            removeExpiredObject(co);
+        }
+    }
+
+    /**
+     * Removes an expired object from the cache.
+     *
+     * @param co The expired CacheObject to be removed.
+     * @throws StorageVolumeException if there is an issue removing the object from the cache volume.
+     */
+    protected void removeExpiredObject(CacheObject co) throws StorageVolumeException {
+        CacheVolume volume = co.volume;
+        if (volume != null && volume.remove(co.name)) {
+            try {
+                inventoryDB.removeObject(co.volname, co.name);
+            } catch (InventoryException e) {
+                throw new StorageVolumeException("Failed to remove object from inventory database: " + co.name, e);
+            }
+        } else {
+            throw new StorageVolumeException("Failed to remove expired object from cache volume: " + co.name);
+        }
+    }
+}

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheck.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheck.java
@@ -12,7 +12,6 @@ import java.time.Instant;
  */
 public class CacheExpiryCheck implements CacheObjectCheck {
 
-    // private static final long TWO_WEEKS_MILLIS = 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
     private StorageInventoryDB inventoryDB;
 
     public CacheExpiryCheck(StorageInventoryDB inventoryDB) {
@@ -21,8 +20,8 @@ public class CacheExpiryCheck implements CacheObjectCheck {
 
     /**
      * Checks if a cache object is expired and removes it from the cache if it is.
-     * The method uses the {@code expiresIn} metadata field to determine the expiration status.
-     * The expiration time is calculated based on the {@code LastModified} time plus the {@code expiresIn} duration.
+     * The method uses the {@code expires} metadata field to determine the expiration status.
+     * The expiration time is calculated based on the {@code LastModified} time plus the {@code expires} duration.
      * If the current time is past the calculated expiry time, the object is removed from the inventory database.
      *
      * @param co The cache object to check for expiration.
@@ -36,10 +35,10 @@ public class CacheExpiryCheck implements CacheObjectCheck {
             throw new IllegalArgumentException("CacheObject or StorageInventoryDB is null");
         }
 
-        if (co.hasMetadatum("expiresIn")) {
-            long expiresInDuration = co.getMetadatumLong("expiresIn", -1L);
-            if (expiresInDuration == -1L) {
-                throw new IntegrityException("Invalid 'expiresIn' metadata value");
+        if (co.hasMetadatum("expires")) {
+            long expiresDuration = co.getMetadatumLong("expires", -1L);
+            if (expiresDuration == -1L) {
+                throw new IntegrityException("Invalid 'expires' metadata value");
             }
 
             long lastModified = co.getLastModified();
@@ -47,7 +46,7 @@ public class CacheExpiryCheck implements CacheObjectCheck {
                 throw new IntegrityException("CacheObject 'lastModified' time not available");
             }
 
-            long expiryTime = lastModified + expiresInDuration;
+            long expiryTime = lastModified + expiresDuration;
             long currentTime = Instant.now().toEpochMilli();
 
             // Check if the object is expired

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
@@ -82,8 +82,6 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
     HeadBagCacheManager hbcm = null;
     long smszlim = 100000000L;  // 100 MB
     Logger log = null;
-    private static final long TWO_WEEKS_MILLIS = 14L * 24 * 60 * 60 * 1000; // 2 weeks in milliseconds
-
 
     /**
      * create the restorer
@@ -652,12 +650,8 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
                     md.put("ediid", resmd.get("ediid"));
                 md.put("cachePrefs", prefs);
 
-                // Add expiresIn metadata for files marked as ROLE_RESTRICTED_DATA
-                if ((prefs & ROLE_RESTRICTED_DATA) != 0) {
-                    // Calculate the expiration time as current time + 2 weeks
-                    long expiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
-                    md.put("expiresIn", expiresIn);
-                }
+                // a hook for handling the expiration logic
+                updateMetadata(md, prefs);
 
                 // find space in the cache, and copy the data file into it
                 try {
@@ -694,6 +688,18 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
 
         if (fix.size() > 0 && manifest != null)
             fixMissingChecksums(into, fix, manifest);
+    }
+
+    /**
+     * Method intended for customization of metadata before caching. This method can be overridden
+     * by subclasses to implement specific metadata customization logic as needed.
+     *
+     * @param md The metadata JSONObject to be customized.
+     * @param prefs flags for data roles
+     */
+    protected void updateMetadata(JSONObject md, int prefs) {
+        // Default implementation does nothing.
+        // Subclasses can override this to implement specific logic.
     }
 
     /**

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
@@ -82,6 +82,8 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
     HeadBagCacheManager hbcm = null;
     long smszlim = 100000000L;  // 100 MB
     Logger log = null;
+    private static final long TWO_WEEKS_MILLIS = 14L * 24 * 60 * 60 * 1000; // 2 weeks in milliseconds
+
 
     /**
      * create the restorer
@@ -649,6 +651,13 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
                 if (resmd.has("ediid"))
                     md.put("ediid", resmd.get("ediid"));
                 md.put("cachePrefs", prefs);
+
+                // Add expiresIn metadata for files marked as ROLE_RESTRICTED_DATA
+                if ((prefs & ROLE_RESTRICTED_DATA) != 0) {
+                    // Calculate the expiration time as current time + 2 weeks
+                    long expiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+                    md.put("expiresIn", expiresIn);
+                }
 
                 // find space in the cache, and copy the data file into it
                 try {

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorer.java
@@ -295,8 +295,8 @@ public class RestrictedDatasetRestorer extends PDRDatasetRestorer {
     protected void updateMetadata(JSONObject md, int prefs) {
         if ((prefs & ROLE_RESTRICTED_DATA) != 0) {
             // Calculate the expiration time as current time + expiryTime
-            long expiresIn = System.currentTimeMillis() + expiryTime;
-            md.put("expiresIn", expiresIn);
+            long expires = System.currentTimeMillis() + expiryTime;
+            md.put("expires", expires);
         }
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
@@ -12,9 +12,11 @@
 package gov.nist.oar.distrib.web;
 
 import gov.nist.oar.distrib.cachemgr.BasicCache;
+import gov.nist.oar.distrib.cachemgr.CacheExpiryCheck;
 import gov.nist.oar.distrib.cachemgr.ConfigurableCache;
 import gov.nist.oar.distrib.cachemgr.CacheManagementException;
 import gov.nist.oar.distrib.cachemgr.CacheVolume;
+import gov.nist.oar.distrib.cachemgr.StorageInventoryDB;
 import gov.nist.oar.distrib.cachemgr.storage.AWSS3CacheVolume;
 import gov.nist.oar.distrib.cachemgr.storage.FilesystemCacheVolume;
 import gov.nist.oar.distrib.cachemgr.VolumeStatus;
@@ -485,6 +487,9 @@ public class NISTCacheManagerConfig {
 
         List<CacheObjectCheck> checks = new ArrayList<CacheObjectCheck>();
         checks.add(new ChecksumCheck(false, true));
+        // Get the StorageInventoryDB from the cache and add the CacheExpiryCheck to the list of checks
+        StorageInventoryDB inventoryDB = cache.getInventoryDB();
+        checks.add(new CacheExpiryCheck(inventoryDB));
         PDRCacheManager out = new PDRCacheManager(cache, rstr, checks, getCheckDutyCycle()*1000, 
                                                   getCheckGracePeriod()*1000, -1, rootdir, logger);
         if (getMonitorAutoStart()) {

--- a/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTCacheManagerConfig.java
@@ -486,10 +486,11 @@ public class NISTCacheManagerConfig {
             throw new ConfigurationException(rootdir+": Not an existing directory");
 
         List<CacheObjectCheck> checks = new ArrayList<CacheObjectCheck>();
-        checks.add(new ChecksumCheck(false, true));
         // Get the StorageInventoryDB from the cache and add the CacheExpiryCheck to the list of checks
         StorageInventoryDB inventoryDB = cache.getInventoryDB();
         checks.add(new CacheExpiryCheck(inventoryDB));
+        checks.add(new ChecksumCheck(false, true));
+
         PDRCacheManager out = new PDRCacheManager(cache, rstr, checks, getCheckDutyCycle()*1000, 
                                                   getCheckGracePeriod()*1000, -1, rootdir, logger);
         if (getMonitorAutoStart()) {

--- a/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
@@ -179,6 +179,12 @@ public class NISTDistribServiceConfig {
 
     @Value("${distrib.packaging.allowedRedirects:1}")
     int allowedRedirects;
+
+    @Value("${distrib.rpa.bagstore-location}")
+    private String rpaBagstore;
+
+    @Value("${distrib.rpa.bagstore-mode}")
+    private String rpaMode;
     
     @Autowired AmazonS3             s3client;    // set via getter below
     @Autowired BagStorage                lts;    // set via getter below
@@ -202,6 +208,25 @@ public class NISTDistribServiceConfig {
         catch (FileNotFoundException ex) {
             throw new ConfigurationException("distrib.bagstore.location",
                                              "Storage Location not found: "+ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * The storage service to use to access the bags, considering the mode and location.
+     */
+    @Bean
+    public BagStorage getBagStorageService() throws ConfigurationException {
+        try {
+            if ("aws".equals(rpaMode) || "remote".equals(rpaMode)) {
+                return new AWSS3LongTermStorage(rpaBagstore, s3client);
+            } else if ("local".equals(rpaMode)) {
+                return new FilesystemLongTermStorage(rpaBagstore);
+            } else {
+                throw new ConfigurationException("distrib.rpa.bagstore-mode", "Unsupported storage mode: " + rpaMode);
+            }
+        } catch (FileNotFoundException ex) {
+            throw new ConfigurationException("distrib.rpa.bagstore-location",
+                    "Storage Location not found: " + ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
@@ -17,14 +17,8 @@ import gov.nist.oar.distrib.service.DefaultDataPackagingService;
 import gov.nist.oar.distrib.service.DefaultPreservationBagService;
 import gov.nist.oar.distrib.service.FileDownloadService;
 import gov.nist.oar.distrib.service.PreservationBagService;
-import gov.nist.oar.distrib.service.RPACachingService;
-import gov.nist.oar.distrib.service.rpa.DefaultRPARequestHandlerService;
-import gov.nist.oar.distrib.service.rpa.JKSKeyRetriever;
-import gov.nist.oar.distrib.service.rpa.KeyRetriever;
-import gov.nist.oar.distrib.service.rpa.RPARequestHandlerService;
 import gov.nist.oar.distrib.storage.AWSS3LongTermStorage;
 import gov.nist.oar.distrib.storage.FilesystemLongTermStorage;
-import gov.nist.oar.distrib.cachemgr.CacheManagementException;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -37,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import javax.activation.MimetypesFileTypeMap;
 
 import org.springframework.boot.SpringApplication;
@@ -46,7 +39,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -179,12 +171,6 @@ public class NISTDistribServiceConfig {
 
     @Value("${distrib.packaging.allowedRedirects:1}")
     int allowedRedirects;
-
-    @Value("${distrib.rpa.bagstore-location}")
-    private String rpaBagstore;
-
-    @Value("${distrib.rpa.bagstore-mode}")
-    private String rpaMode;
     
     @Autowired AmazonS3             s3client;    // set via getter below
     @Autowired BagStorage                lts;    // set via getter below
@@ -211,24 +197,6 @@ public class NISTDistribServiceConfig {
         }
     }
 
-    /**
-     * The storage service to use to access the bags, considering the mode and location.
-     */
-    @Bean
-    public BagStorage getBagStorageService() throws ConfigurationException {
-        try {
-            if ("aws".equals(rpaMode) || "remote".equals(rpaMode)) {
-                return new AWSS3LongTermStorage(rpaBagstore, s3client);
-            } else if ("local".equals(rpaMode)) {
-                return new FilesystemLongTermStorage(rpaBagstore);
-            } else {
-                throw new ConfigurationException("distrib.rpa.bagstore-mode", "Unsupported storage mode: " + rpaMode);
-            }
-        } catch (FileNotFoundException ex) {
-            throw new ConfigurationException("distrib.rpa.bagstore-location",
-                    "Storage Location not found: " + ex.getMessage(), ex);
-        }
-    }
 
     /**
      * the client for access S3 storage

--- a/src/main/java/gov/nist/oar/distrib/web/RPACachingServiceProvider.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPACachingServiceProvider.java
@@ -177,7 +177,9 @@ public class RPACachingServiceProvider {
     public RestrictedDatasetRestorer createRPDatasetRestorer()
         throws ConfigurationException, IOException, CacheManagementException
     {
-        return new RestrictedDatasetRestorer(pubstore, getRPBagStorage(), getHeadBagCacheManager());
+        RestrictedDatasetRestorer rdr = new RestrictedDatasetRestorer(pubstore, getRPBagStorage(), getHeadBagCacheManager());
+        rdr.setExpiryTime(rpacfg.getExpiresAfterMillis());
+        return rdr;
         // return new PDRDatasetRestorer(getRPBagStorage(), getHeadBagCacheManager());
     }
 

--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -53,7 +53,8 @@ public class RPAConfiguration {
     String bagStore = null;
     @JsonProperty("bagstore-mode")
     String mode = null;
-
+    @JsonProperty("expiresAfterMillis")
+    long expiresAfterMillis = 0L;
 
     public long getHeadbagCacheSize() {
         return hbCacheSize;
@@ -74,6 +75,14 @@ public class RPAConfiguration {
     }
     public void setBagstoreMode(String mode) {
         this.mode = mode;
+    }
+
+    public long getExpiresAfterMillis() {
+        return expiresAfterMillis;
+    }
+
+    public void setExpiresAfterMillis(long expiresAfterMillis) {
+        this.expiresAfterMillis = expiresAfterMillis;
     }
 
     public SalesforceJwt getSalesforceJwt() {

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheckTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheckTest.java
@@ -1,0 +1,102 @@
+package gov.nist.oar.distrib.cachemgr;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CacheExpiryCheckTest {
+
+    @Mock
+    private StorageInventoryDB mockInventoryDB;
+    @Mock
+    private CacheVolume mockVolume;
+    @Mock
+    private CacheObject cacheObject;
+    private CacheExpiryCheck expiryCheck;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        expiryCheck = new CacheExpiryCheck(mockInventoryDB);
+    }
+
+    /**
+     * Test to verify that {@link CacheExpiryCheck} correctly identifies and processes an expired cache object.
+     * An object is considered expired if its last modified time is more than two weeks ago.
+     * This test checks that the expired object is appropriately removed from both the cache volume and the inventory
+     * database.
+     *
+     * @throws Exception to handle any exceptions thrown during the test execution
+     */
+    @Test
+    public void testExpiredObject() throws Exception {
+        // Setup mock
+        cacheObject.name = "testObject";
+        cacheObject.volname = "testVolume";
+        cacheObject.volume = mockVolume;
+        long lastModified = System.currentTimeMillis() - (15 * 24 * 60 * 60 * 1000); // 15 days in milliseconds
+        when(cacheObject.getLastModified()).thenReturn(lastModified);
+
+
+        when(mockVolume.remove("testObject")).thenReturn(true);
+
+        // Perform the check
+        expiryCheck.check(cacheObject);
+
+        // Verify the interactions
+        verify(mockVolume).remove("testObject");
+        verify(mockInventoryDB).removeObject(anyString(), anyString());
+    }
+
+
+    /**
+     * Test to ensure that {@link CacheExpiryCheck} does not flag a cache object as expired if it has been
+     * modified within the last two weeks. This test checks that no removal action is taken for a non-expired object.
+     *
+     * @throws Exception to handle any exceptions thrown during the test execution
+     */
+    @Test
+    public void testNonExpiredObject() throws Exception {
+        // Setup mock
+        cacheObject.name = "nonExpiredObject";
+        cacheObject.volname = "testVolume";
+        cacheObject.volume = mockVolume;
+
+        long lastModified = System.currentTimeMillis() - (5 * 24 * 60 * 60 * 1000); // 5 days in milliseconds
+        when(cacheObject.getLastModified()).thenReturn(lastModified);
+
+        // Perform the check
+        expiryCheck.check(cacheObject);
+
+        // Verify that the remove method was not called as the object is not expired
+        verify(mockVolume, never()).remove("nonExpiredObject");
+        verify(mockInventoryDB, never()).removeObject("testVolume", "nonExpiredObject");
+    }
+
+    /**
+     * Test to verify that {@link CacheExpiryCheck} throws an {@link IntegrityException} when the last modified time
+     * of a cache object is unknown (indicated by a value of -1). This situation should be flagged as an error
+     * as the expiry status of the object cannot be determined.
+     *
+     * @throws Exception to handle any exceptions thrown during the test execution
+     */
+    @Test(expected = IntegrityException.class)
+    public void testUnknownLastModifiedTime() throws Exception {
+        // Setup mock
+        cacheObject.name = "unknownLastModifiedObject";
+        cacheObject.volname = "testVolume";
+        cacheObject.volume = mockVolume;
+        long lastModified = -1; // Unknown last modified time
+        when(cacheObject.getLastModified()).thenReturn(lastModified);
+
+        // Perform the check, expecting an IntegrityException
+        expiryCheck.check(cacheObject);
+    }
+
+}

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorerTest.java
@@ -407,7 +407,7 @@ public class RestrictedDatasetRestorerTest {
     }
 
     @Test
-    public void testExpiresIn() throws StorageVolumeException, ResourceNotFoundException, CacheManagementException {
+    public void testExpires() throws StorageVolumeException, ResourceNotFoundException, CacheManagementException {
 
         assertTrue(! cache.isCached("mds1491/trial1.json"));
         assertTrue(! cache.isCached("mds1491/trial2.json"));
@@ -429,33 +429,33 @@ public class RestrictedDatasetRestorerTest {
 
         List<CacheObject> found = cache.getInventoryDB().findObject("mds1491/trial1.json", VolumeStatus.VOL_FOR_INFO);
         assertEquals(1, found.size());
-        assertTrue("CacheObject should contain expiresIn metadata", found.get(0).hasMetadatum("expiresIn"));
+        assertTrue("CacheObject should contain expires metadata", found.get(0).hasMetadatum("expires"));
 
-        // Verify the "expiresIn" value is approximately 2 weeks from the current time
+        // Verify the "expires" value is approximately 2 weeks from the current time
         long TWO_WEEKS_MILLIS = 14L * 24 * 60 * 60 * 1000;
-        long expectedExpiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
-        long actualExpiresIn = found.get(0).getMetadatumLong("expiresIn", 0);
-        // Check that the absolute difference between the expected and actual expiresIn values is less than 1000ms
-        assertTrue("expiresIn should be set to 2 weeks from the current time",
-                Math.abs(expectedExpiresIn - actualExpiresIn) < 1000);
+        long expectedExpires = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+        long actualExpires = found.get(0).getMetadatumLong("expires", 0);
+        // Check that the absolute difference between the expected and actual expires values is less than 1000ms
+        assertTrue("expires field should be set to 2 weeks from the current time",
+                Math.abs(expectedExpires - actualExpires) < 1000);
 
         found = cache.getInventoryDB().findObject("mds1491/trial2.json", VolumeStatus.VOL_FOR_INFO);
         assertEquals(1, found.size());
-        assertTrue("CacheObject should contain expiresIn metadata", found.get(0).hasMetadatum("expiresIn"));
+        assertTrue("CacheObject should contain expires metadata", found.get(0).hasMetadatum("expires"));
 
-        expectedExpiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
-        actualExpiresIn = found.get(0).getMetadatumLong("expiresIn", 0);
-        assertTrue("expiresIn should be set to 2 weeks from the current time",
-                Math.abs(expectedExpiresIn - actualExpiresIn) < 1000);
+        expectedExpires= System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+        actualExpires = found.get(0).getMetadatumLong("expires", 0);
+        assertTrue("expires field should be set to 2 weeks from the current time",
+                Math.abs(expectedExpires - actualExpires) < 1000);
 
         found = cache.getInventoryDB().findObject("mds1491/README.txt", VolumeStatus.VOL_FOR_INFO);
         assertEquals(1, found.size());
-        assertTrue("CacheObject should contain expiresIn metadata", found.get(0).hasMetadatum("expiresIn"));
+        assertTrue("CacheObject should contain expires metadata", found.get(0).hasMetadatum("expires"));
 
-        expectedExpiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
-        actualExpiresIn = found.get(0).getMetadatumLong("expiresIn", 0);
-        assertTrue("expiresIn should be set to 2 weeks from the current time",
-                Math.abs(expectedExpiresIn - actualExpiresIn) < 1000);
+        expectedExpires = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+        actualExpires = found.get(0).getMetadatumLong("expires", 0);
+        assertTrue("expires field should be set to 2 weeks from the current time",
+                Math.abs(expectedExpires - actualExpires) < 1000);
 
     }
 

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorerTest.java
@@ -406,5 +406,58 @@ public class RestrictedDatasetRestorerTest {
 
     }
 
+    @Test
+    public void testExpiresIn() throws StorageVolumeException, ResourceNotFoundException, CacheManagementException {
+
+        assertTrue(! cache.isCached("mds1491/trial1.json"));
+        assertTrue(! cache.isCached("mds1491/trial2.json"));
+        assertTrue(! cache.isCached("mds1491/trial3/trial3a.json"));
+        assertTrue(! cache.isCached("mds1491/README.txt"));
+
+        Set<String> cached = rstr.cacheDataset("mds1491", null, cache, true,
+                PDRCacheRoles.ROLE_RESTRICTED_DATA, null);
+        assertTrue(cached.contains("trial1.json"));
+        assertTrue(cached.contains("trial2.json"));
+        assertTrue(cached.contains("README.txt"));
+        assertTrue(cached.contains("trial3/trial3a.json"));
+        assertEquals(4, cached.size());
+
+        assertTrue(cache.isCached("mds1491/trial1.json"));
+        assertTrue(cache.isCached("mds1491/trial2.json"));
+        assertTrue(cache.isCached("mds1491/README.txt"));
+        assertTrue(cache.isCached("mds1491/trial3/trial3a.json"));
+
+        List<CacheObject> found = cache.getInventoryDB().findObject("mds1491/trial1.json", VolumeStatus.VOL_FOR_INFO);
+        assertEquals(1, found.size());
+        assertTrue("CacheObject should contain expiresIn metadata", found.get(0).hasMetadatum("expiresIn"));
+
+        // Verify the "expiresIn" value is approximately 2 weeks from the current time
+        long TWO_WEEKS_MILLIS = 14L * 24 * 60 * 60 * 1000;
+        long expectedExpiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+        long actualExpiresIn = found.get(0).getMetadatumLong("expiresIn", 0);
+        // Check that the absolute difference between the expected and actual expiresIn values is less than 1000ms
+        assertTrue("expiresIn should be set to 2 weeks from the current time",
+                Math.abs(expectedExpiresIn - actualExpiresIn) < 1000);
+
+        found = cache.getInventoryDB().findObject("mds1491/trial2.json", VolumeStatus.VOL_FOR_INFO);
+        assertEquals(1, found.size());
+        assertTrue("CacheObject should contain expiresIn metadata", found.get(0).hasMetadatum("expiresIn"));
+
+        expectedExpiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+        actualExpiresIn = found.get(0).getMetadatumLong("expiresIn", 0);
+        assertTrue("expiresIn should be set to 2 weeks from the current time",
+                Math.abs(expectedExpiresIn - actualExpiresIn) < 1000);
+
+        found = cache.getInventoryDB().findObject("mds1491/README.txt", VolumeStatus.VOL_FOR_INFO);
+        assertEquals(1, found.size());
+        assertTrue("CacheObject should contain expiresIn metadata", found.get(0).hasMetadatum("expiresIn"));
+
+        expectedExpiresIn = System.currentTimeMillis() + TWO_WEEKS_MILLIS;
+        actualExpiresIn = found.get(0).getMetadatumLong("expiresIn", 0);
+        assertTrue("expiresIn should be set to 2 weeks from the current time",
+                Math.abs(expectedExpiresIn - actualExpiresIn) < 1000);
+
+    }
+
 }
 

--- a/src/test/java/gov/nist/oar/distrib/web/RPACachingServiceProviderTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPACachingServiceProviderTest.java
@@ -1,5 +1,6 @@
 package gov.nist.oar.distrib.web;
 
+import gov.nist.oar.distrib.cachemgr.pdr.RestrictedDatasetRestorer;
 import gov.nist.oar.distrib.storage.FilesystemLongTermStorage;
 import gov.nist.oar.distrib.BagStorage;
 import gov.nist.oar.distrib.cachemgr.CacheManagementException;
@@ -81,6 +82,7 @@ public class RPACachingServiceProviderTest {
     public void testCreateRPDatasetRestorer()
         throws ConfigurationException, IOException, CacheManagementException
     {
-        PDRDatasetRestorer rest = prov.createRPDatasetRestorer();
+        RestrictedDatasetRestorer rest = prov.createRPDatasetRestorer();
+        assertEquals(rest.getExpiryTime(), 1209600000L);
     }
 }

--- a/src/test/java/gov/nist/oar/distrib/web/RPAConfigurationTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPAConfigurationTest.java
@@ -22,5 +22,6 @@ public class RPAConfigurationTest {
         assertEquals("local", config.getBagstoreMode());
         assertNull(config.getBagstoreLocation());
         assertEquals("1234567890 pdr.rpa.2023 1234567890", config.getJwtSecretKey());
+        assertEquals(1209600000L, config.getExpiresAfterMillis());
     }
 }

--- a/src/test/resources/rpaconfig.json
+++ b/src/test/resources/rpaconfig.json
@@ -3,5 +3,6 @@
   "datacartUrl": "https://localhost/datacart/rpa",
   "headbagCacheSize": 50000000,
   "bagstoreMode": "local",
-  "jwtSecretKey": "1234567890 pdr.rpa.2023 1234567890"
+  "jwtSecretKey": "1234567890 pdr.rpa.2023 1234567890",
+  "expiresAfterMillis": 1209600000
 }


### PR DESCRIPTION
This PR introduces the **CacheExpiryCheck** class, an enhancement to our cache management system. This new feature automates the process of identifying and removing cache objects that have expired, i.e. objects older than two weeks.

### Changes:

- **CacheExpiryCheck** is a new class implementing the **CacheObjectCheck** interface. It checks whether cache objects are expired and removes them if they are.
- **CacheExpiryCheck** is integrated into the existing cache management workflow; this new check will be integrated into the **BasicIntegrityMonitor**'s existing workflow. It will be added to the list of checks that are performed on cache objects. When **BasicIntegrityMonitor** executes its routine checks, it will now also check for object expiry alongside other integrity checks.
- This new class uses the **StorageInventoryDB** under the hood to update the cache inventory and remove expired cache objects.
- The **createCacheManager()** method of the **NISTCacheManagerConfig** class has been updated to include the **CacheExpiryCheck**. This new check is added to the list of cache object checks, leveraging the **StorageInventoryDB** obtained from the **BasicCache**.

### Testing:

- Unit tests have been added to validate the functionality of **CacheExpiryCheck** under various scenarios, including handling expired objects, non-expired objects, and objects with unknown last modified times.
-  Testing with oar-docker: pending
