### PR TITLE
Add Email and Country Blacklisting

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -1,5 +1,6 @@
 package gov.nist.oar.distrib.web;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -53,6 +54,11 @@ public class RPAConfiguration {
     String bagStore = null;
     @JsonProperty("bagstore-mode")
     String mode = null;
+    @JsonProperty("disallowedEmails")
+    private List<String> disallowedEmails = new ArrayList<>();
+
+    @JsonProperty("disallowedCountries")
+    private List<String> disallowedCountries = new ArrayList<>();
 
 
     public long getHeadbagCacheSize() {
@@ -187,6 +193,22 @@ public class RPAConfiguration {
 
     public void setJwtSecretKey(String jwtSecretKey) {
         this.jwtSecretKey = jwtSecretKey;
+    }
+
+    public List<String> getDisallowedEmails() {
+        return disallowedEmails;
+    }
+
+    public void setDisallowedEmailStrings(List<String> disallowedEmails) {
+        this.disallowedEmails = disallowedEmails;
+    }
+
+    public List<String> getDisallowedCountries() {
+        return disallowedCountries;
+    }
+
+    public void setDisallowedCountries(List<String> disallowedCountries) {
+        this.disallowedCountries = disallowedCountries;
     }
 
     @NoArgsConstructor

--- a/src/test/java/gov/nist/oar/distrib/web/RPAConfigurationTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPAConfigurationTest.java
@@ -22,5 +22,16 @@ public class RPAConfigurationTest {
         assertEquals("local", config.getBagstoreMode());
         assertNull(config.getBagstoreLocation());
         assertEquals("1234567890 pdr.rpa.2023 1234567890", config.getJwtSecretKey());
+
+        // assertions for disallowed email strings and countries
+        assertNotNull(config.getDisallowedEmails());
+        assertEquals(2, config.getDisallowedEmails().size());
+        assertTrue(config.getDisallowedEmails().contains("@123\\."));
+        assertTrue(config.getDisallowedEmails().contains("@example\\.com$"));
+
+        assertNotNull(config.getDisallowedCountries());
+        assertEquals(2, config.getDisallowedCountries().size());
+        assertTrue(config.getDisallowedCountries().contains("Cuba"));
+        assertTrue(config.getDisallowedCountries().contains("North Korea"));
     }
 }

--- a/src/test/resources/rpaconfig.json
+++ b/src/test/resources/rpaconfig.json
@@ -3,5 +3,13 @@
   "datacartUrl": "https://localhost/datacart/rpa",
   "headbagCacheSize": 50000000,
   "bagstoreMode": "local",
-  "jwtSecretKey": "1234567890 pdr.rpa.2023 1234567890"
+  "jwtSecretKey": "1234567890 pdr.rpa.2023 1234567890",
+  "disallowedEmails": [
+    "@123\\.",
+    "@example\\.com$"
+  ],
+  "disallowedCountries": [
+    "Cuba",
+    "North Korea"
+  ]
 }


### PR DESCRIPTION
## Overview

This PR introduces functionality to automatically reject record creation requests in the `createRecord()` method when the user's email or country is blacklisted. 

## Changes

- Implemented new `isEmailBlacklisted()` and `isCountryBlacklisted()` methods to check if the user's email or country is in the blacklist. 
- Blacklist validation is the first thing we do in `createRecord()`. This ensures that requests with blacklisted emails or countries are rejected right away, which prevents unnecessary processing and resource utilization on entries that will ultimately be automatically rejected.
- Added logging to record when a request is rejected due to blacklisting.
- Updated unit tests to cover scenarios where the email or country is blacklisted.

## Testing

- Updated existing unit tests to cover the new blacklisting checks.
- e2e testing with oar-docker to ensure that blacklisted emails and countries are correctly identified and rejected.

Please review the changes and provide your feedback.
