### PR TITLE
Fix file naming on Safari downloads

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -493,7 +493,7 @@ public class DatasetAccessController {
 	    response.setHeader("Content-Length", Long.toString(sh.getInfo().contentLength));
 	    response.setHeader("Content-Type", sh.getInfo().contentType);
 	    response.setHeader("Content-Disposition",
-		    "filename=\"" + Pattern.compile("/+").matcher(filepath).replaceAll("_") + "\"");
+		    "attachment;filename=\"" + Pattern.compile("/+").matcher(filepath).replaceAll("_") + "\"");
 
 	    int len;
 	    byte[] buf = new byte[100000];


### PR DESCRIPTION
This PR addresses and resolves an issue encountered in the Safari browser, where downloaded files were named "download" regardless of their intended filenames. The root cause was the absence of the "**attachment**" keyword in the [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header. Prefixing the filename in the Content-Disposition header with "attachment" ensures that the specified filename overrides the download attribute content in Safari. In Chrome and Firefox, the filename specified in the Content-Disposition header takes precedence and is used for the downloaded file, regardless of the presence or absence of the "download" attribute in the anchor tag.

Testing using oar-docker was done across all three browsers: Safari, Chrome, and Firefox. The tests confirmed that files are now downloaded using the names specified in the Content-Disposition header.