### PR TITLE
Change purpose of selectDatasetObjects from INFO to GET

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
@@ -104,7 +104,7 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
         logger.debug("Requesting metadata for temporary ID=" + randomID);
         JSONArray metadata = new JSONArray();
         List<CacheObject> objects = this.pdrCacheManager.selectDatasetObjects(randomID,
-                this.pdrCacheManager.VOL_FOR_INFO);
+                this.pdrCacheManager.VOL_FOR_GET);
         if (objects.size() > 0) {
             for (CacheObject obj : objects) {
                 JSONObject objMd = formatMetadata(obj.exportMetadata(), randomID);

--- a/src/test/java/gov/nist/oar/distrib/service/RPACachingServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/RPACachingServiceTest.java
@@ -116,7 +116,7 @@ public class RPACachingServiceTest {
 
         List<CacheObject> cacheObjects = Arrays.asList(cacheObject1, cacheObject2);
 
-        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_INFO))
+        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_GET))
                 .thenReturn(cacheObjects);
 
         String testBaseDownloadUrl = "https://testdata.nist.gov";
@@ -192,7 +192,7 @@ public class RPACachingServiceTest {
 
         List<CacheObject> cacheObjects = Arrays.asList(cacheObject1, cacheObject2);
 
-        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_INFO))
+        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_GET))
                 .thenReturn(cacheObjects);
 
         String testBaseDownloadUrl = "https://testdata.nist.gov";
@@ -241,7 +241,7 @@ public class RPACachingServiceTest {
 
         List<CacheObject> cacheObjects = Arrays.asList(cacheObject1);
 
-        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_INFO))
+        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_GET))
                 .thenReturn(cacheObjects);
 
         rpaCachingService.retrieveMetadata(randomID);
@@ -252,7 +252,7 @@ public class RPACachingServiceTest {
 
         String randomID = "randomId123";
         List<CacheObject> objects = new ArrayList<>();
-        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_INFO)).thenReturn(objects);
+        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_GET)).thenReturn(objects);
 
         rpaCachingService.retrieveMetadata(randomID);
     }
@@ -292,7 +292,7 @@ public class RPACachingServiceTest {
 
         List<CacheObject> cacheObjects = Arrays.asList(cacheObject1, cacheObject2);
 
-        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_INFO))
+        when(pdrCacheManager.selectDatasetObjects(randomID, pdrCacheManager.VOL_FOR_GET))
                 .thenReturn(cacheObjects);
 
         String testBaseDownloadUrl = "htp://testdata.nist.gov/";


### PR DESCRIPTION
This PR update the **selectDatasetObjects** method to use the **VOL_FOR_GET** purpose for retrieving objects, instead of **VOL_FOR_INFO**,  to prevent metadata retrieval after file or dataset uncaching.