### PR TITLE
Remove RPA Config log statement

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -177,9 +177,6 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
         // Set HttpClient
         this.httpClient = HttpClients.createDefault();
-
-        // Log RPA configuration coming from the config server
-        LOGGER.debug("RPA_CONFIGURATION=" + this.rpaConfiguration.toString());
     }
 
     public RPAConfiguration getConfig() {


### PR DESCRIPTION
This PR removes the following debug line that was displaying the entire RPA configuration, including sensitive information such as secrets:

```java
LOGGER.debug("RPA_CONFIGURATION=" + this.rpaConfiguration.toString());
```