### PR TITLE
Enable dataset cache requests based source bag

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/CacheOpts.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/CacheOpts.java
@@ -1,0 +1,73 @@
+/**
+ * This software was developed at the National Institute of Standards and Technology by employees of
+ * the Federal Government in the course of their official duties. Pursuant to title 17 Section 105
+ * of the United States Code this software is not subject to copyright protection and is in the
+ * public domain. This is an experimental system. NIST assumes no responsibility whatsoever for its
+ * use by other parties, and makes no guarantees, expressed or implied, about its quality,
+ * reliability, or any other characteristic. We would appreciate acknowledgement if the software is
+ * used. This software can be redistributed and/or modified freely provided that any derivative
+ * works bear some notice that they are derived from it, and any modified versions bear some notice
+ * that they have been modified.
+ * 
+ * @author: Raymond Plante
+ */
+package gov.nist.oar.distrib.cachemgr.pdr;
+
+/**
+ * an object for collecting options used for caching data.
+ */
+public class CacheOpts {
+    public int prefs = 0;
+    public String seq = null;
+    public boolean recache = false;
+
+    public CacheOpts() { }
+
+    public CacheOpts(boolean recache, int prefs, String seq) {
+        this.prefs = prefs;
+        this.recache = recache;
+        this.seq = seq;
+    }
+
+    public String serialize() {
+        StringBuilder sb = new StringBuilder("re=");
+        sb.append((recache) ? "1" : "0");
+        if (seq != null) {
+            if (sb.length() > 0) sb.append(",");
+            sb.append("seq=").append(seq);
+        }
+        if (prefs != 0) {
+            if (sb.length() > 0) sb.append(",");
+            sb.append("pr=").append(Integer.toString(prefs));
+        }
+        return sb.toString();
+    }
+
+    public static CacheOpts parse(String optstr) {
+        CacheOpts out = new CacheOpts();
+        if (optstr == null || optstr.equals("0"))  // legacy syntax
+            return out;
+        if (optstr.equals("1")) {                   // legacy syntax
+            out.recache = true;
+            return out;
+        }
+        
+        String[] opts = optstr.split(",\\s*");
+        for (String opt : opts) {
+            String[] kv = opt.split("=", 2);
+            if (kv.length > 1) {
+                kv[0] = kv[0].toLowerCase();
+                if ("recache".startsWith(kv[0]))
+                    out.recache = kv[1].equals("1");
+                else if ("prefs".startsWith(kv[0])) {
+                    try { out.prefs = Integer.parseInt(kv[1]); }
+                    catch (NumberFormatException ex) { }
+                }
+                else if ("sequence".startsWith(kv[0]))
+                    out.seq = kv[1];
+            }       
+        }
+
+        return out;
+    }
+}

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
@@ -215,13 +215,30 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
     /**
      * queue up a dataset or file object to be cached asynchronously via a separate thread
      * @param id   the full aipid for the dataset or object (of the form DSID[/FILEPATH][#VERSION])
+     * @param recache  if true, request that files already in the cache be recached from scratch; 
+     *                 if false, such files will not be updated.
      */
     public void queueCache(String id, boolean recache)
         throws ResourceNotFoundException, StorageVolumeException, CacheManagementException
     {
+        queueCache(id, recache, null);
+    }
+
+    /**
+     * queue up a dataset or file object to be cached asynchronously via a separate thread
+     * @param id   the full aipid for the dataset or object (of the form DSID[/FILEPATH][#VERSION])
+     * @param recache  if true, request that files already in the cache be recached from scratch; 
+     *                 if false, such files will not be updated.
+     * @param sequence a string for restricting the files from the dataset that get restored.  The 
+     *                 value is matched against the bagfile sequence number; only those files contained
+     *                 in that bag will be restored.  
+     */
+    public void queueCache(String id, boolean recache, String sequence)
+        throws ResourceNotFoundException, StorageVolumeException, CacheManagementException
+    {
         if (restorer.doesNotExist(id))
             throw new ResourceNotFoundException(id);
-        cath.queue(id, recache);
+        cath.queue(id, recache, sequence);
         if (! cath.isAlive())
             cath.start();
     }
@@ -629,6 +646,23 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
     }
 
     /**
+     * cache all of the files from the given dataset
+     * @param dsid     the AIP identifier for the dataset; this is either the old-style EDI-ID or 
+     *                   local portion of the PDR ARK identifier (e.g., <code>"mds2-2119"</code>).  
+     * @param version  the desired version of the dataset or null for the latest version
+     * @param recache  if false and a file is already in the cache, the file will not be rewritten;
+     *                    otherwise, all current cached files from the dataset will be replaced with a 
+     *                    fresh copy.
+     * @param prefs    any ANDed preferences for how to cache the data (particularly, where).  
+     * @param target   a prefix collection name to insert the data files into within the cache
+     */
+    public Set<String> cacheDataset(String dsid, String version, CacheOpts opts, String target)
+        throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
+    {
+        return ((PDRDatasetRestorer) restorer).cacheDataset(dsid, version, theCache, opts, target);
+    }
+
+    /**
      * a thread that will cache data in order of their IDs in an internal queue.  Objects can be added 
      * to the queue via {@link #queue(String)}.
      * <p>
@@ -685,8 +719,13 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
             return _queue;
         }
 
-        public synchronized void queue(String aipid, boolean recache) throws CacheManagementException {
-            aipid += "\t"+((recache) ? "1" : "0");
+        public void queue(String aipid, boolean recache) throws CacheManagementException {
+            queue(aipid, recache, null);
+        }
+
+        public synchronized void queue(String aipid, boolean recache, String seq) throws CacheManagementException {
+            CacheOpts opts = new CacheOpts(recache, 0, seq);
+            aipid += "\t"+opts.serialize();
             try {
                 BufferedWriter out = new BufferedWriter(new FileWriter(_queuef, true));
                 try {
@@ -712,7 +751,7 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
         public boolean isQueued(String aipid) {
             try {
                 Queue<String> _queue = loadQueue();
-                return _queue.contains(aipid+"\t0") || _queue.contains(aipid+"\t1");
+                return ! _queue.stream().noneMatch(e -> e.startsWith(aipid+"\t"));
             } catch (IOException ex) {
                 log.error("isQueued: status of "+aipid+" unknown; "+
                           "Can't access queue's persistent cache: "+ ex.getMessage());
@@ -740,12 +779,14 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
         }
 
         protected String cacheQueueItem(String qitem) throws CacheManagementException {
-            boolean recache = true;
             String[] parts = qitem.split("\\s*\\t\\s*");
             String nextid = parts[0];
             inprocess = nextid;
-            if (parts.length > 1 && "0".equals(parts[1]))
-                recache = false;
+
+            CacheOpts opts = new CacheOpts();
+            if (parts.length > 1) 
+                opts = CacheOpts.parse(parts[1]);
+
             String version = null;
             if (parts.length > 2) version = parts[2];
             
@@ -753,8 +794,8 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
             try {
                 if (parts[1].length() == 0) 
                     // dataset identifier
-                    cacheDataset(parts[0], version, recache, 0, null);
-                else if (recache || ! isCached(nextid))
+                    cacheDataset(parts[0], version, opts.recache, 0, null);
+                else if (opts.recache || ! isCached(nextid))
                     // data file identifier
                     cache(nextid, true);
             }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManager.java
@@ -794,7 +794,7 @@ public class PDRCacheManager extends PDRDatasetCacheManager implements PDRConsta
             try {
                 if (parts[1].length() == 0) 
                     // dataset identifier
-                    cacheDataset(parts[0], version, opts.recache, 0, null);
+                    cacheDataset(parts[0], version, opts, null);
                 else if (opts.recache || ! isCached(nextid))
                     // data file identifier
                     cache(nextid, true);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
@@ -465,6 +465,8 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
                 if (bagf.endsWith("-"+opts.seq))
                     uselu.put(bagf, revlu.get(bagf));
             }
+            if (uselu.size() == 0) 
+                log.warn("Sequence tag does not match any bag files for requested version");
         }
 
         // loop through the member bags and extract the data files

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorer.java
@@ -384,7 +384,23 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
                                     int prefs, String target)
         throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
     {
-        return cacheDatasetFromStore(aipid, version, into, recache, prefs, target, ltstore);
+        CacheOpts opts = new CacheOpts(recache, prefs, null);
+        return cacheDatasetFromStore(aipid, version, into, opts, target, ltstore);
+    }
+
+    /**
+     * cache all data that is part of a the latest version of the archive information package (AIP).
+     * @param aipid    the identifier for the AIP.  
+     * @param version  the version of the AIP to cache.  If null, the latest is cached. 
+     * @param into     the Cache to save the files to 
+     * @param recache  if false and a file is already in the cache, the file will not be rewritten;
+     *                    otherwise, it will be.  
+     * @return Set<String> -- a list of the filepaths for files that were cached
+     */
+    public Set<String> cacheDataset(String aipid, String version, Cache into, CacheOpts opts, String target)
+        throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
+    {
+        return cacheDatasetFromStore(aipid, version, into, opts, target, ltstore);
     }
 
     /**
@@ -392,8 +408,8 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
      * from a particular store.  Called by {@link cacheDataset}, this is provided to allow alternate 
      * implementations by subclasses.
      */
-    protected Set<String> cacheDatasetFromStore(String aipid, String version, Cache into, boolean recache, 
-                                              int prefs, String target,  BagStorage store)
+    protected Set<String> cacheDatasetFromStore(String aipid, String version, Cache into, CacheOpts opts,
+                                              String target,  BagStorage store)
             throws StorageVolumeException, ResourceNotFoundException, CacheManagementException
     {
         // find the head bag in the bag store
@@ -402,8 +418,8 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
             throw new CacheManagementException("Unsupported serialization type on bag: " + headbag);
         String bagname = headbag.substring(0, headbag.length()-4);
         String mbagver = BagUtils.multibagVersionOf(bagname);
-        if (prefs == 0) {
-            prefs = getDefaultPrefs(version != null);
+        if (opts.prefs == 0) {
+            opts.prefs = getDefaultPrefs(version != null);
         }
         // pull out the NERDm resource metadata record
         JSONObject resmd = null;
@@ -442,16 +458,25 @@ public class PDRDatasetRestorer implements Restorer, PDRConstants, PDRCacheRoles
             revlu.get(pair.getValue()).add(pair.getKey().replaceFirst("^data/", ""));
         }
 
+        HashMap<String, Set<String>> uselu = revlu;
+        if (opts.seq != null) {
+            uselu = new HashMap<String, Set<String>>();
+            for (String bagf : revlu.keySet()) {
+                if (bagf.endsWith("-"+opts.seq))
+                    uselu.put(bagf, revlu.get(bagf));
+            }
+        }
+
         // loop through the member bags and extract the data files
         Set<String> cached = new HashSet<String>(lu.size());
         Set<String> missing = new HashSet<String>();
-        for (String bagfile : revlu.keySet()) {
-            Set<String> need = new HashSet<String>(revlu.get(bagfile));
+        for (String bagfile : uselu.keySet()) {
+            Set<String> need = new HashSet<String>(uselu.get(bagfile));
             if (! bagfile.endsWith(".zip"))
                 bagfile += ".zip";
             log.info("Caching files from bag, "+bagfile);
             try { 
-               cacheFromBag(bagfile, need, cached, resmd, prefs, version, into, recache, target);
+               cacheFromBag(bagfile, need, cached, resmd, opts.prefs, version, into, opts.recache, target);
             }
             catch (FileNotFoundException ex) {
                 log.error("Member bag not found in store (skipping): "+bagfile);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorer.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/pdr/RestrictedDatasetRestorer.java
@@ -253,13 +253,12 @@ public class RestrictedDatasetRestorer extends PDRDatasetRestorer {
             throws StorageVolumeException, ResourceNotFoundException, CacheManagementException {
 
         Set<String> cachedFiles;
+        CacheOpts opts = new CacheOpts(recache, prefs, null);
 
         try {
-            cachedFiles = cacheDatasetFromStore(aipid, version, into, recache, prefs, target,
-                                                restrictedLtstore);
+            cachedFiles = cacheDatasetFromStore(aipid, version, into, opts, target, restrictedLtstore);
         } catch (ResourceNotFoundException ex) {
-            cachedFiles = cacheDatasetFromStore(aipid, version, into, recache, prefs, target,
-                                                ltstore);
+            cachedFiles = cacheDatasetFromStore(aipid, version, into, opts, target, ltstore);
         }
 
         return cachedFiles;

--- a/src/main/java/gov/nist/oar/distrib/web/CacheManagementController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/CacheManagementController.java
@@ -17,6 +17,7 @@ import gov.nist.oar.distrib.cachemgr.CacheManagementException;
 import gov.nist.oar.distrib.cachemgr.CacheObject;
 import gov.nist.oar.distrib.cachemgr.InventoryException;
 import gov.nist.oar.distrib.cachemgr.VolumeNotFoundException;
+import gov.nist.oar.distrib.cachemgr.pdr.CacheOpts;
 import gov.nist.oar.distrib.DistributionException;
 import gov.nist.oar.distrib.ResourceNotFoundException;
 import gov.nist.oar.distrib.StorageVolumeException;
@@ -319,10 +320,11 @@ public class CacheManagementController {
             id += "#"+version;
         String recachep = request.getParameter("recache");
         boolean recache = ! ("0".equals(recachep) || "false".equals(recachep));
+        String seq = request.getParameter("seq");
         
         if (":cached".equals(selector)) {
             try {
-                mgr.queueCache(id, recache);
+                mgr.queueCache(id, recache, seq);
                 log.info("Queued for caching: {}", id);
                 return new ResponseEntity<String>("Cache target queued", HttpStatus.ACCEPTED);
             } catch (ResourceNotFoundException ex) {

--- a/src/main/java/gov/nist/oar/distrib/web/CacheManagementController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/CacheManagementController.java
@@ -319,7 +319,7 @@ public class CacheManagementController {
         if (version != null)
             id += "#"+version;
         String recachep = request.getParameter("recache");
-        boolean recache = ! ("0".equals(recachep) || "false".equals(recachep));
+        boolean recache = ! (recachep == null || "0".equals(recachep) || "false".equals(recachep));
         String seq = request.getParameter("seq");
         
         if (":cached".equals(selector)) {

--- a/src/main/java/gov/nist/oar/distrib/web/CacheManagementController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/CacheManagementController.java
@@ -325,7 +325,7 @@ public class CacheManagementController {
         if (":cached".equals(selector)) {
             try {
                 mgr.queueCache(id, recache, seq);
-                log.info("Queued for caching: {}", id);
+                log.info("Queued for caching: {} {}", id, ((seq==null) ? "" : "seq="+seq));
                 return new ResponseEntity<String>("Cache target queued", HttpStatus.ACCEPTED);
             } catch (ResourceNotFoundException ex) {
                 return new ResponseEntity<String>("Resource not found", HttpStatus.NOT_FOUND);

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/CacheOptsTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/CacheOptsTest.java
@@ -1,0 +1,65 @@
+/**
+ * This software was developed at the National Institute of Standards and Technology by employees of
+ * the Federal Government in the course of their official duties. Pursuant to title 17 Section 105
+ * of the United States Code this software is not subject to copyright protection and is in the
+ * public domain. This is an experimental system. NIST assumes no responsibility whatsoever for its
+ * use by other parties, and makes no guarantees, expressed or implied, about its quality,
+ * reliability, or any other characteristic. We would appreciate acknowledgement if the software is
+ * used. This software can be redistributed and/or modified freely provided that any derivative
+ * works bear some notice that they are derived from it, and any modified versions bear some notice
+ * that they have been modified.
+ * 
+ * @author: Raymond Plante
+ */
+package gov.nist.oar.distrib.cachemgr.pdr;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.Assert.*;
+
+public class CacheOptsTest {
+
+    @Test
+    public void testParse() {
+        CacheOpts opts = new CacheOpts();
+        assertFalse(opts.recache);
+        assertNull(opts.seq);
+        assertEquals(0, opts.prefs);
+
+        opts = CacheOpts.parse("recache=1");
+        assertTrue(opts.recache);
+        assertNull(opts.seq);
+        assertEquals(0, opts.prefs);
+
+        opts = CacheOpts.parse("r=1,seq=14");
+        assertTrue(opts.recache);
+        assertEquals(opts.seq, "14");
+        assertEquals(0, opts.prefs);
+
+        opts = CacheOpts.parse("r=1,seq=goob,pref=3,rec=0");
+        assertFalse(opts.recache);
+        assertEquals(opts.seq, "goob");
+        assertEquals(3, opts.prefs);
+    }
+
+    @Test
+    public void testSerialize() {
+        CacheOpts opts = new CacheOpts();
+        assertEquals("re=0", opts.serialize());
+
+        opts.seq = "2112";
+        assertEquals("re=0,seq=2112", opts.serialize());
+
+        opts.recache = true;
+        assertEquals("re=1,seq=2112", opts.serialize());
+
+        opts.prefs = 3;
+        assertEquals("re=1,seq=2112,pr=3", opts.serialize());
+
+        opts.seq = null;
+        assertEquals("re=1,pr=3", opts.serialize());
+    }
+}

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManagerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRCacheManagerTest.java
@@ -428,7 +428,7 @@ public class PDRCacheManagerTest {
         assertTrue(mgr.cath.hasPending());
         assertTrue(mgr.cath.isQueued("mds2-1111"));
         mgr.cath.queue("mds2-2222", false);
-        mgr.cath.queue("mds2-3333", true);
+        mgr.cath.queue("mds2-3333", true, "222");
         assertTrue(mgr.cath.hasPending());
         assertTrue(mgr.cath.isQueued("mds2-1111"));
         assertTrue(mgr.cath.isQueued("mds2-2222"));
@@ -436,8 +436,8 @@ public class PDRCacheManagerTest {
         q = mgr.cath.loadQueue();
         assertEquals(3, q.size());
         assertEquals("mds2-1111\t0", mgr.cath.popQueue());
-        assertEquals("mds2-2222\t0", mgr.cath.popQueue());
-        assertEquals("mds2-3333\t1", mgr.cath.popQueue());
+        assertEquals("mds2-2222\tre=0", mgr.cath.popQueue());
+        assertEquals("mds2-3333\tre=1,seq=222", mgr.cath.popQueue());
         assertTrue(! mgr.cath.hasPending());
         assertTrue(!mgr.cath.isQueued("mds2-1111"));
         assertTrue(!mgr.cath.isQueued("mds2-2222"));

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorerTest.java
@@ -305,6 +305,37 @@ public class PDRDatasetRestorerTest {
         assertTrue(! cache.isCached("67C783D4BA814C8EE05324570681708A1899/NMRRVocab20171102.rdf.sha256"));
     }
 
+
+    @Test
+    public void testCacheWithCacheOpts() 
+        throws StorageVolumeException, ResourceNotFoundException, CacheManagementException,
+               FileNotFoundException
+    {
+        assertTrue(! cache.isCached("mds1491/trial1.json#1.1.0"));
+        assertTrue(! cache.isCached("mds1491/trial2.json#1.1.0"));
+        assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#1.1.0"));
+        assertTrue(! cache.isCached("mds1491/trial1.json#8"));
+        assertTrue(! cache.isCached("mds1491/trial2.json#8"));
+        assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#8"));
+
+        CacheOpts opts = new CacheOpts(false, 0, "0");
+
+        Set<String> cached = rstr.cacheDataset("mds1491", "1.1.0", cache, opts, null);
+
+        assertTrue(! cached.contains("trial1.json"));
+        assertTrue(cached.contains("trial2.json"));
+        assertTrue(! cached.contains("trial3/trial3a.json"));
+        assertEquals(1, cached.size());
+
+        assertTrue(! cache.isCached("mds1491/trial1.json#1.1.0"));
+        assertTrue(cache.isCached("mds1491/trial2.json#1.1.0"));
+        assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#1.1.0"));
+        assertTrue(! cache.isCached("mds1491/trial1.json#8"));
+        assertTrue(! cache.isCached("mds1491/trial2.json#8"));
+        assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#8"));
+
+    }    
+
     @Test
     public void testCacheFromBagSelect() 
         throws StorageVolumeException, ResourceNotFoundException, CacheManagementException,

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/pdr/PDRDatasetRestorerTest.java
@@ -334,6 +334,9 @@ public class PDRDatasetRestorerTest {
         assertTrue(! cache.isCached("mds1491/trial2.json#8"));
         assertTrue(! cache.isCached("mds1491/trial3/trial3a.json#8"));
 
+        opts = new CacheOpts(false, 0, "99");
+        cached = rstr.cacheDataset("mds1491", "1.1.0", cache, opts, null);
+        assertEquals(cached.size(), 0);
     }    
 
     @Test


### PR DESCRIPTION
The cache management API allows an admin to request either specific data files or whole data sets to be cached.  This proved limiting when caching very large datasets if any large part of the caching failed, the only practical remedy was to try caching the whole dataset again.  This PR addresses this limitation by allowing one to request caching of all files from a particular bag.  This provides more granularity in a request but which is more efficient than requesting individual files.  

This change was implemented in support of mds2-2775, dataset of 10^4 files.  