### PR TITLE
Add Support for Pre-Approved Datasets

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -417,12 +417,13 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     }
 
     private JsonNode fetchDatasetMetadata(String datasetUrl) {
+        HttpURLConnection connection = null; 
         try {
             URL url = new URL(datasetUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json");
-
+    
             if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
                     return new ObjectMapper().readTree(in);
@@ -432,9 +433,14 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
             }
         } catch (IOException e) {
             LOGGER.debug("Error retrieving metadata: " + e.getMessage());
+        } finally {
+            if (connection != null) {
+                connection.disconnect(); // Close connection
+            }
         }
-        return null;
+        return null; // Return null if metadata fetch fails
     }
+    
 
     private boolean checkForPreApproval(JsonNode metadata, String datasetId) {
         JsonNode components = metadata.path("components");

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -71,6 +71,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
     private final static String RECORD_PENDING_STATUS = "pending";
     private final static String RECORD_APPROVED_STATUS = "approved";
+    private final static String RECORD_PRE_APPROVED_STATUS = "pre-approved";
     private final static String RECORD_DECLINED_STATUS = "declined";
     private final static String RECORD_REJECTED_STATUS = "rejected";
 
@@ -269,21 +270,19 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
      * @throws InvalidRequestException   If the request is invalid or incomplete.
      * @throws RequestProcessingException If an error occurs during request processing, including URL creation, serialization, or communication errors.
      */
-
     @Override
-    public RecordWrapper createRecord(UserInfoWrapper userInfoWrapper) throws InvalidRequestException,
-            RequestProcessingException {
+    public RecordWrapper createRecord(UserInfoWrapper userInfoWrapper) throws InvalidRequestException, RequestProcessingException {
         int responseCode;
-
+        RecordWrapper newRecordWrapper;
+    
         // Validate the email and country against the blacklists before proceeding
         String email = userInfoWrapper.getUserInfo().getEmail();
         String country = userInfoWrapper.getUserInfo().getCountry();
         String rejectionReason = "";
-
-        // Log user info
+    
         LOGGER.debug("User's email: " + email);
         LOGGER.debug("User's country: " + country);
-
+    
         // Check for blacklisted email and country
         if (isEmailBlacklisted(email)) {
             rejectionReason = "Email " + email + " is blacklisted.";
@@ -292,29 +291,23 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
             rejectionReason = "Country " + country + " is blacklisted.";
             LOGGER.warn("Country {} is blacklisted. Request to create record will be automatically rejected.", country);
         }
-
-        // Set the pending status of the record in this service, and not based on the user's input
-        userInfoWrapper.getUserInfo().setApprovalStatus(RECORD_PENDING_STATUS);
-
+    
+        // Set the appropriate approval status based on blacklisting
         if (!rejectionReason.isEmpty()) {
-            // Append the rejection reason to the existing description
-            String currentDescription = userInfoWrapper.getUserInfo().getDescription();
-            String updatedDescription = currentDescription + "\nThis record was automatically rejected. Reason: " + rejectionReason;
-            userInfoWrapper.getUserInfo().setDescription(updatedDescription);
-            // Set approval status to rejected
             userInfoWrapper.getUserInfo().setApprovalStatus(RECORD_REJECTED_STATUS);
+            String updatedDescription = userInfoWrapper.getUserInfo().getDescription() +
+                    "\nThis record was automatically rejected. Reason: " + rejectionReason;
+            userInfoWrapper.getUserInfo().setDescription(updatedDescription);
+        } else {
+            // Set pending or pre-approved status based on dataset type
+            String datasetId = userInfoWrapper.getUserInfo().getSubject();
+            boolean isPreApproved = isPreApprovedDataset(datasetId);
+            userInfoWrapper.getUserInfo().setApprovalStatus(isPreApproved ? RECORD_PRE_APPROVED_STATUS : RECORD_PENDING_STATUS);
         }
-
-        // Initialize return value
-        RecordWrapper newRecordWrapper;
-
-        // Get path
+    
+        // Send the POST request to Salesforce
         String createRecordUri = getConfig().getSalesforceEndpoints().get(CREATE_RECORD_ENDPOINT_KEY);
-
-        // Get token
         JWTToken token = jwtHelper.getToken();
-
-        // Build URL
         String url;
         try {
             url = new URIBuilder(token.getInstanceUrl())
@@ -325,89 +318,91 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
             throw new RequestProcessingException("Error building URI: " + e.getMessage());
         }
         LOGGER.debug("CREATE_RECORD_URL=" + url);
-
+    
+        // Serialize the request payload
         String postPayload;
         try {
             postPayload = prepareRequestPayload(userInfoWrapper);
-            // Log the payload before serialization
             LOGGER.debug("CREATE_RECORD_PAYLOAD=" + postPayload);
         } catch (JsonProcessingException e) {
             LOGGER.error("Error while preparing record creation payload: " + e.getMessage());
             throw new RequestProcessingException("Error while preparing record creation payload: " + e.getMessage());
         }
-
-        // Send POST request
+    
+        // Send the POST request
         HttpURLConnection connection = null;
-
+    
         try {
             URL requestUrl = new URL(url);
             connection = connectionFactory.createHttpURLConnection(requestUrl);
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("Authorization", "Bearer " + token.getAccessToken());
-            // Set payload
-            byte[] payloadBytes = postPayload.getBytes(StandardCharsets.UTF_8);
-            connection.setDoOutput(true); // tell connection we are writing data to the output stream
-            OutputStream os = connection.getOutputStream();
-            os.write(payloadBytes);
-            os.flush();
-            os.close();
-
+            connection.setDoOutput(true);
+    
+            // Write payload to output stream
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(postPayload.getBytes(StandardCharsets.UTF_8));
+                os.flush();
+            }
+    
+            // Process Salesforce response
             responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) { // If created
+            if (responseCode == HttpURLConnection.HTTP_OK) {
                 try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
                     StringBuilder response = new StringBuilder();
                     String line;
-
                     while ((line = in.readLine()) != null) {
                         response.append(line);
                     }
                     LOGGER.debug("CREATE_RECORD_RESPONSE=" + response);
-                    // Handle the response
                     newRecordWrapper = new ObjectMapper().readValue(response.toString(), RecordWrapper.class);
                 }
             } else {
-                // Handle any other error response
                 LOGGER.debug("Error response from Salesforce service: " + connection.getResponseMessage());
                 throw new RequestProcessingException("Error response from Salesforce service: " + connection.getResponseMessage());
             }
-
-        } catch (MalformedURLException e) {
-            // Handle the URL Malformed error
-            LOGGER.debug("Invalid URL: " + e.getMessage());
-            throw new RequestProcessingException("Invalid URL: " + e.getMessage());
         } catch (IOException e) {
-            // Handle the I/O error
-            LOGGER.debug("Error sending GET request: " + e.getMessage());
+            LOGGER.debug("Error sending request: " + e.getMessage());
             throw new RequestProcessingException("I/O error: " + e.getMessage());
         } finally {
-            // Close the connection
             if (connection != null) {
                 connection.disconnect();
             }
         }
-
-        // Check if success and handle accordingly
+    
+        // Handle record creation based on the dataset type and approval status
         if (newRecordWrapper != null) {
-            // Check if the record is marked as rejected before proceeding
-            if (!RECORD_REJECTED_STATUS.equals(newRecordWrapper.getRecord().getUserInfo().getApprovalStatus())) {
-                // If the record is not marked as rejected, proceed with the normal success handling,
-                // including sending emails for SME approval and to the requester.
-                this.recordResponseHandler.onRecordCreationSuccess(newRecordWrapper.getRecord());
+            String approvalStatus = newRecordWrapper.getRecord().getUserInfo().getApprovalStatus();
+    
+            if (RECORD_REJECTED_STATUS.equals(approvalStatus)) {
+                LOGGER.info("Record automatically rejected due to blacklist. Skipping further processing.");
+            } else if (RECORD_PRE_APPROVED_STATUS.equals(approvalStatus)) {
+                // Handle pre-approved dataset: cache immediately and send both confirmation and download emails
+                String randomId = this.rpaDatasetCacher.cache(userInfoWrapper.getUserInfo().getSubject());
+                if (randomId == null) {
+                    throw new RequestProcessingException("Caching process returned a null randomId");
+                }
+                this.recordResponseHandler.onPreApprovedRecordCreationSuccess(newRecordWrapper.getRecord(), randomId);
             } else {
-                // Since the record is automatically rejected, we skip sending approval and notification emails.
-                LOGGER.info("Record automatically rejected due to blacklist. Skipping email notifications.");
+                // Handle SME-required dataset: send SME approval request and confirmation email
+                this.recordResponseHandler.onRecordCreationSuccess(newRecordWrapper.getRecord());
             }
         } else {
-            // we expect a record to be created every time we call createRecord
-            // if newRecordWrapper is null, it means creation failed
+            // Handle failure if record creation did not succeed
             this.recordResponseHandler.onRecordCreationFailure(responseCode);
         }
-
-
+    
         return newRecordWrapper;
     }
+    
 
+    private boolean isPreApprovedDataset(String datasetId) {
+        List<RPAConfiguration.Approver.ApproverData> approvers = rpaConfiguration.getApprovers().get(datasetId);
+        return approvers == null || approvers.isEmpty();
+    }
+    
+     
     private boolean isEmailBlacklisted(String email) {
         List<String> disallowedEmailStrings = rpaConfiguration.getDisallowedEmails();
         for (String patternString : disallowedEmailStrings) {
@@ -432,7 +427,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         // Serialize the userInfoWrapper object to JSON
         return new ObjectMapper().writeValueAsString(userInfoWrapper);
     }
-
+    
 
     /**
      * Updates the status of a record in the database.

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RecordResponseHandler.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RecordResponseHandler.java
@@ -20,6 +20,13 @@ public interface RecordResponseHandler {
     void onRecordCreationFailure(int statusCode);
 
     /**
+     * Called when a pre-approved record creation operation succeeds.
+     * @param record The newly created pre-approved record
+     * @param randomId The unique identifier for the cached dataset associated with the record
+     */
+    void onPreApprovedRecordCreationSuccess(Record record, String randomId);
+
+    /**
      * This method is called when a record update operation is successful and user was approved.
      * @param record The record that was the user approved for.
      */

--- a/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -136,6 +137,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         service.setRecordResponseHandler(recordResponseHandler);
         service.seRPADatasetCacher(rpaDatasetCacher);
         service.setHttpClient(mockHttpClient);
+
+        // Set up mock behavior for rpaConfiguration
+        when(rpaConfiguration.getBaseDownloadUrl()).thenReturn("https://data.nist.gov/od/ds/");
 
         // Set up mock behavior for mockJwtHelper
         testToken = new JWTToken(TEST_ACCESS_TOKEN, TEST_INSTANCE_URL);


### PR DESCRIPTION
### Overview

This PR updates the record handling logic in our distribution service to differentiate between datasets that require SME approval and those that are pre-approved.

### Changes

- Updated the `createRecord()` method to first create records in Salesforce then handle all post-processing (caching, emailing) based on the dataset type, only after successful creation.
- Added a new `RECORD_PRE_APPROVED_STATUS`, which is used for datasets that are pre-approved, allowing them to be cached and sent to the user without SME intervention.
- ~~Leveraged the RPA configuration to identify pre-approved datasets; each dataset ID is mapped to a set of approvers in the configuration file. If no approvers are specified for a given dataset ID, it is considered pre-approved. **This is just temporary until we add the new metadata fields.**~~ Replaced the configuration-based logic with a metadata-based check: pre-approval is determined by parsing the NERDm metadata, looking for components with "@type" containing `nrdp:RestrictedAccessPage` and verifying that the `pdr:accessProfile` field has a "@type" value of `rpa:rp0`.
- Added a new method in `RecordResponseHandlerImpl` to handle pre-approved datasets by sending both confirmation and download emails in a single step.

### Updated workflow

- User submits request to download dataset.
- `createRecord` will be called with user info.
- Blacklist Check: rejects user if email/country is blacklisted.
- Dataset Type Check: sets `RECORD_PRE_APPROVED_STATUS` if pre-approved; otherwise, `RECORD_PENDING_STATUS`.
- Salesforce Record Creation: sends request to create a record in Salesforce.
- Post-Processing:
  - Rejected: ends process.
  - Pre-approved: caches dataset, sends confirmation and download emails.
  - SME-required: sends confirmation email to user and approval email request to SME.
- SME Approval (when required):
  - Approve: caches dataset, sends download link to user.
  - Decline: updates status to declined, notifies user.

### Testing

- Tested end-to-end using oar-docker. I was able to download files, **only individually**.