### PR TITLE
Updates to Data Packaging Service

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/datapackage/DefaultDataPackager.java
+++ b/src/main/java/gov/nist/oar/distrib/datapackage/DefaultDataPackager.java
@@ -132,8 +132,13 @@ public class DefaultDataPackager implements DataPackager {
 			 *End of part for logs
 			*/
 
+			logger.info("Original filepath: {}", filepath);
+			logger.info("Extracted record ID: {}", recordid);
+			logger.info("Extracted filename: {}", filedir);
+	
 			// The modified file path
 			String modifiedFilePath = recordid + "/" + filedir;
+			logger.info("Modified file path for zip entry: {}", modifiedFilePath);
 			
 			if (this.validateUrl(downloadurl)) {
 				

--- a/src/main/java/gov/nist/oar/distrib/datapackage/ResIdProcessorTest.java
+++ b/src/main/java/gov/nist/oar/distrib/datapackage/ResIdProcessorTest.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.datapackage;public class ResIdProcessorTest {
+}

--- a/src/test/java/gov/nist/oar/distrib/web/DataBundleAccessControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/DataBundleAccessControllerTest.java
@@ -98,7 +98,7 @@ public class DataBundleAccessControllerTest {
 
 	assertEquals(HttpStatus.OK, response.getStatusCode());
 	assertTrue(response.getHeaders().getFirst("Content-Type").startsWith("application/zip"));
-	assertEquals(59918, response.getBody().length());
+	assertEquals(59916, response.getBody().length());
 
     }
 


### PR DESCRIPTION
This PR updates to the Distribution Service, particularly the Data Packaging Service, to address the feedback from Greg.

### Changes

1. Update Max Zip Size

- The **distrib.packaging.maxpackagesize** parameter already handles requested zip size. (Current setting is 4GB)

2. File Name Updates for RPA

- Renamed zip file to: **NIST-Data-[timestamp]**. Timestamp is in a human readable format indicating the date and time of download.
- Note: This change is implemented in the datacart frontend code and will have its own [PR](https://github.com/usnistgov/oar-pdr/pull/354).

3. Status Renaming

- Renamed status filenames for clarity:
  - PackagingSuccessful → DownloadSuccessful
  - PackagingErrors → DownloadErrors
- Replaced all occurrences of "Packaging" with "Download".

4. Update Package Hierarchy

- Removed ark:/88434/ from the package hierarchy.
- New hierarchy: The dataset name makes a folder at the root of the zip file, with data files organized within this folder.
- New logic:
  - If the dataset name contains ark, the dataset ID is used as the folder name.
  - If the dataset ID is a 32-34 character string (e.g., "3A1EE2F169DD3B8CE0531A570681DB5D1491"), only the last 2 or 4 characters are retained and prefixed with **"mds2-00"** or **"mds2-"**.


### Testing:
- All updates were tested locally using `oar-docker` to verify the changes work as intended.