### PR TITLE
Add Region Configuration to S3 Client Setup

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
+++ b/src/main/java/gov/nist/oar/distrib/web/NISTDistribServiceConfig.java
@@ -141,7 +141,7 @@ public class NISTDistribServiceConfig {
     /**
      * the AWS region the service should operate in; this is ignored if mode=local.
      */
-    @Value("${cloud.aws.region:@null}")
+    @Value("${cloud.aws.region:us-east-1}")
     String region;
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,10 @@ server:
     max-threads: 200
     min-spare-threads: 10
 
+cloud:
+  aws:
+    region: us-east-1
+
 logging:
   file: distservice.log
   path: /var/log/dist-service

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       enabled: false
 
 server:
-  port: 8083
+  port: 0 # Avoid conflict with actual service running port 8083
 
 distrib:
   bagstore:


### PR DESCRIPTION
This PR fixes an issue where the S3 client initialization fails due to a missing region.

### Changes

- Added the region property to the `application.yml` configuration file.
```yaml
cloud:
  aws:
    region: us-east-1
```

- Set a default value for the region variable used in the `getAmazonS3()` method.
```java
@Value("${cloud.aws.region:us-east-1}")
String region;
```
- Set service port to 0 (random) in unit tests to prevent conflicts with the actual service running on port 8083.

### Testing
- Unit tests pass.
- Verified that the application starts successfully using `oar-docker`.