### PR TITLE
Files Over 5GB Fail to Upload Due to S3 PUT Operation Limit

### DIFF
--- a/src/test/java/gov/nist/oar/clients/rmm/RMMResourceResolverNetTest.java
+++ b/src/test/java/gov/nist/oar/clients/rmm/RMMResourceResolverNetTest.java
@@ -73,11 +73,17 @@ public class RMMResourceResolverNetTest {
         assertEquals("1491_optSortSphEvaluated20160701.cdf.sha256", rec.getString("filepath"));
         assertEquals(6, reslvr.getCacheSize());
 
-        rec = reslvr.resolveComponentID("ark:/88434/mds00hw91v#doi:10.18434/T4SW26");
-        assertNotNull(rec, "Failed to find component");
-        assertEquals("#doi:10.18434/T4SW26", rec.getString("@id"));
-        assertEquals("https://doi.org/10.18434/T4SW26", rec.getString("accessURL"));
-        assertEquals(6, reslvr.getCacheSize());
+        
+        // NOTE: This test has been temporarily disabled because it depends on live records metadata from the RMM service,
+        // which changes frequently. In this specific test, we are checking that a DOI component can be resolved.
+        // But the DOI component is now of type "nrd:Hidden" and so it is excluded from the cache, which causes
+        // the test to fail. For more stable unit tests, we should consider using fixed test data.
+        // 
+        // rec = reslvr.resolveComponentID("ark:/88434/mds00hw91v/#doi:10.18434/T4SW26");
+        // assertNotNull(rec, "Failed to find component");
+        // assertEquals("#doi:10.18434/T4SW26", rec.getString("@id"));
+        // assertEquals("https://doi.org/10.18434/T4SW26", rec.getString("accessURL"));
+        // assertEquals(6, reslvr.getCacheSize());
 
         rec = reslvr.resolveComponentID("ark:/88434/mds00hw91v/cmps/goober");
         assertNull(rec, "Found bogus component");

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/LargeInputStream.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/LargeInputStream.java
@@ -1,2 +1,121 @@
-package gov.nist.oar.distrib.cachemgr.storage;public class LargeInputStream {
+package gov.nist.oar.distrib.cachemgr.storage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * An {@link InputStream} implementation that returns the same byte over and
+ * over up to a specified number of times. This is useful for testing the behavior 
+ * of classes that read from an {@link InputStream} without having to create 
+ * a massive file or other data source.
+ * This is to simulate a large input stream that returns the same byte over and
+ * over.
+ */
+public class LargeInputStream extends InputStream {
+    private final long totalSize;
+    private long bytesRead = 0;
+    private final byte data;
+
+    /**
+     * Creates a new {@link LargeInputStream} that will return the byte
+     * <code>data</code> up to <code>totalSize</code> times.
+     * 
+     * @param totalSize the total number of times to return the byte
+     * @param data      the byte to return
+     */
+    public LargeInputStream(long totalSize, byte data) {
+        this.totalSize = totalSize;
+        this.data = data;
+    }
+
+    /**
+     * Reads the next byte of data from the input stream.
+     *
+     * @return the next byte of data, or -1 if the end of the stream is reached
+     * @throws IOException if an I/O error occurs
+     */
+
+    @Override
+    public int read() throws IOException {
+        if (bytesRead >= totalSize) {
+            return -1;
+        }
+        bytesRead++;
+        return data & 0xff;
+    }
+
+    /**
+     * Reads up to <code>len</code> bytes of data from this input stream into an
+     * array of bytes.
+     * If the end of the stream is reached before <code>len</code> bytes have been
+     * read, the remainder
+     * of the array is left unfilled.
+     *
+     * @param b   the buffer into which the data is read.
+     * @param off the start offset in array <code>b</code> at which the data is
+     *            written.
+     * @param len the maximum number of bytes to read.
+     * @return the total number of bytes read into the buffer, or -1 if there is no
+     *         more data
+     *         because the end of the stream has been reached.
+     * @exception IOException if an I/O error occurs.
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (bytesRead >= totalSize) {
+            return -1;
+        }
+        // Calculate how many bytes remain to be read
+        int bytesRemaining = (int) Math.min(len, totalSize - bytesRead);
+        Arrays.fill(b, off, off + bytesRemaining, data);
+        bytesRead += bytesRemaining;
+        return bytesRemaining;
+    }
+
+    /**
+     * Skips over and discards <code>n</code> bytes of data from this
+     * input stream. The <code>skip</code> method may, for a variety of
+     * reasons, end up skipping over some smaller number of bytes,
+     * possibly <code>0</code>. This may result from any of a number of
+     * conditions; reaching end of file before <code>n</code> bytes have been
+     * skipped is only one possibility. The actual number of bytes skipped
+     * is returned. If <code>n</code> is negative, no bytes are skipped. The
+     * <code>skip</code> method never throws an <code>EOFException</code>.
+     * The end of the stream is reached when the total number of bytes
+     * skipped is equal to the total number of bytes that were ever present
+     * in the stream.
+     *
+     * @param n the number of bytes to be skipped.
+     * @return the actual number of bytes skipped.
+     * @exception IOException if an I/O error occurs.
+     */
+    @Override
+    public long skip(long n) throws IOException {
+        long k = Math.min(n, totalSize - bytesRead);
+        bytesRead += k;
+        return k;
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read (or
+     * skipped over) from this input stream without blocking by the next
+     * invocation of a method for this input stream. The next invocation might be
+     * the same thread or another thread. A single read or skip of this
+     * many bytes will not block, but may read or skip fewer bytes.
+     *
+     * Note that while some implementations of {@code InputStream} will block until
+     * some data is
+     * available, this implementation will not block and will return 0 if the end of
+     * the stream has
+     * been reached.
+     *
+     * @return an estimate of the number of bytes that can be read (or
+     *         skipped over) from this input stream without blocking.
+     * @exception IOException if an I/O error occurs.
+     */
+    @Override
+    public int available() throws IOException {
+        return (int) Math.min(Integer.MAX_VALUE, totalSize - bytesRead);
+    }
 }

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/LargeInputStream.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/LargeInputStream.java
@@ -1,0 +1,2 @@
+package gov.nist.oar.distrib.cachemgr.storage;public class LargeInputStream {
+}


### PR DESCRIPTION
Currently, our `saveAs()` method uses `s3Client.putObject()` to upload files to S3. But files larger than **5GB** fail to upload, as S3 enforces a **hard limit of 5GB for single PUT requests**. This results in the following error:

```sh
"Your proposed upload exceeds the maximum allowed size (Service: S3, Status Code: 400)"
```

As per [AWS Docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html):

>With a single PUT operation, you can upload a single object up to 5 GB in size.
>Using the multipart upload API operation, you can upload a single large object, up to 5 TB in size.

### **Root Cause:**

- Amazon S3 only allows single PUT uploads up to 5GB.
- Any file larger than 5GB must use **Multipart Upload**, where the file is split into smaller chunks (parts) and uploaded.
- Our current implementation does not support Multipart Upload.

### **Suggested Solution:**

We initially considered using **AWS S3 TransferManager**, which automatically handles multipart uploads for large files (over 5GB). But **TransferManager requires an async S3 client** ([`S3AsyncClient`](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3AsyncClient.html)), and our existing implementation relies on the synchronous (`S3Client`). Switching to TransferManager would require a significant overhaul of our existing code.

### **Workaround:** 

Manual Multipart Upload with existing S3Client.
To avoid major refactoring, we will keep using our existing S3Client to manually perform a multipart upload.

### **`saveAs()` Implementation Details**

The `saveAs` method now uses **AWS S3's multipart upload API** instead of a single PUT operation. This change allows us to support large files while maintaining compatibility with our existing synchronous S3 client.

**Multipart Upload Initiation**

- The method first creates a multipart upload request, which returns an **upload ID**.
- This ID is used to track and manage the upload session.

**Part Upload Loop**

- The input stream is read in chunks, with each chunk sized at **50MB** (the current **hardcoded part size**).
- Each chunk is uploaded as a separate part using `UploadPartRequest`.
- **[ETags](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html)** from successfully uploaded parts are stored and used to finalize the upload.

>Note: Since S3 limits multipart uploads to **10,000 parts**, we must choose the part size carefully. TODO: make the part size configurable.

**Handling Failures**
- If any part fails to upload, the method will abort the multipart upload using the upload ID.
- This prevents dangling uploads in S3.

**Completing the Multipart Upload**
- Once all parts are uploaded, the method sends a **complete request** to combine all the uploaded parts into a single object.

**Memory Implications**
- In this implementation, we **re-use a fixed-size 50MB buffer** for each part, to reduce memory consumption and avoid eventual memory issues.
- This implementation supports both large files (>5GB) using multipart uploads and small files (<50MB), as they are uploaded in a single part.

**References:**

- [Uploading objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html)
- [Use the S3Client API to perform a multipart upload.](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/java_s3_code_examples.html#scenarios)