### PR TITLE
Fix URL encoding for Unicode and special characters in redirect URLs

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -669,7 +670,14 @@ public class AWSS3CacheVolume implements CacheVolume {
             }
         } else {
             try {
-                return new URL(baseurl + name.replace(" ", "%20"));
+                // properly encode the URL
+                URL url = UriComponentsBuilder.fromHttpUrl(baseurl)
+                        .pathSegment(name.split("/"))
+                        .encode()
+                        .build()
+                        .toUri()
+                        .toURL();
+                return url;
             } catch (MalformedURLException ex) {
                 throw new StorageVolumeException("Failed to form legal URL: " + ex.getMessage(), ex);
             }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolume.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -28,7 +29,7 @@ import java.util.List;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -671,13 +672,9 @@ public class AWSS3CacheVolume implements CacheVolume {
         } else {
             try {
                 // properly encode the URL
-                URL url = UriComponentsBuilder.fromHttpUrl(baseurl)
-                        .pathSegment(name.split("/"))
-                        .encode()
-                        .build()
-                        .toUri()
-                        .toURL();
-                return url;
+                String encodedName = UriUtils.encodePath(name, StandardCharsets.UTF_8);
+                String url = baseurl.endsWith("/") ? baseurl + encodedName : baseurl + "/" + encodedName;
+                return new URL(url);
             } catch (MalformedURLException ex) {
                 throw new StorageVolumeException("Failed to form legal URL: " + ex.getMessage(), ex);
             }

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.net.MalformedURLException;
 
 import org.json.JSONObject;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -317,7 +318,14 @@ public class FilesystemCacheVolume implements CacheVolume {
         if (baseurl == null)
             throw new UnsupportedOperationException("FilesystemCacheVolume: getRedirectFor not supported");
         try {
-            return new URL(baseurl + name.replace(" ", "%20"));
+            // properly encode the URL
+            URL url = UriComponentsBuilder.fromHttpUrl(baseurl)
+                    .pathSegment(name.split("/"))
+                    .encode()
+                    .build()
+                    .toUri()
+                    .toURL();
+            return url;
         }
         catch (MalformedURLException ex) {
             throw new StorageVolumeException("Failed to form legal URL: "+ex.getMessage(), ex);

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolume.java
@@ -23,13 +23,14 @@ import java.io.IOException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Instant;
 import java.net.URL;
 import java.net.MalformedURLException;
 
 import org.json.JSONObject;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -319,13 +320,9 @@ public class FilesystemCacheVolume implements CacheVolume {
             throw new UnsupportedOperationException("FilesystemCacheVolume: getRedirectFor not supported");
         try {
             // properly encode the URL
-            URL url = UriComponentsBuilder.fromHttpUrl(baseurl)
-                    .pathSegment(name.split("/"))
-                    .encode()
-                    .build()
-                    .toUri()
-                    .toURL();
-            return url;
+            String encodedName = UriUtils.encodePath(name, StandardCharsets.UTF_8);
+            String url = baseurl.endsWith("/") ? baseurl + encodedName : baseurl + "/" + encodedName;
+            return new URL(url);
         }
         catch (MalformedURLException ex) {
             throw new StorageVolumeException("Failed to form legal URL: "+ex.getMessage(), ex);

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/AWSS3CacheVolumeTest.java
@@ -551,6 +551,11 @@ public class AWSS3CacheVolumeTest {
         s3cv = new AWSS3CacheVolume(bucket, "cach", s3client, "https://ex.org/");
         assertEquals(new URL("https://ex.org/goober"), s3cv.getRedirectFor("goober"));
         assertEquals(new URL("https://ex.org/i%20a/m%20groot"), s3cv.getRedirectFor("i a/m groot"));
+
+        // New test case with Unicode and special characters like α,β,γ
+        String name = "folder/EDS map αβγ #file.tiff";
+        String expected = "https://ex.org/folder/EDS%20map%20%CE%B1%CE%B2%CE%B3%20%23file.tiff";
+        assertEquals(new URL(expected), s3cv.getRedirectFor(name));
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolumeTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/storage/FilesystemCacheVolumeTest.java
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.time.Instant;
 
 import org.json.JSONObject;
@@ -207,6 +208,11 @@ public class FilesystemCacheVolumeTest {
             // Use URI instead of URL
             assertEquals(new URI("https://ex.org/goober"), v.getRedirectFor("goober").toURI());
             assertEquals(new URI("https://ex.org/i%20a/m%20groot"), v.getRedirectFor("i a/m groot").toURI());
+
+            // New test case with Unicode and special characters like α,β,γ
+            String name = "folder/EDS map αβγ #file.tiff";
+            String expected = "https://ex.org/folder/EDS%20map%20%CE%B1%CE%B2%CE%B3%20%23file.tiff";
+            assertEquals(new URI(expected), v.getRedirectFor(name).toURI());
         } catch (URISyntaxException e) {
             fail("URI syntax is incorrect: " + e.getMessage());
         }


### PR DESCRIPTION
This PR fixes an issue with incorrect URL encoding in `getRedirectFor(String name)` implementations for both `FilesystemCacheVolume` and `AWSS3CacheVolume`.

## Changes

Make sure the new logic handles:
  - Unicode characters (e.g., α, β, γ)
  - Reserved characters (#, %, etc.)
  - Spaces to %20

Replaced:

```java
return new URL(baseurl + name.replace(" ", "%20"));
```
with:

```java
URL url = UriComponentsBuilder.fromHttpUrl(baseurl)
        .pathSegment(name.split("/"))
        .encode()
        .build()
        .toUri()
        .toURL();
return url;
```

Updated Unit Tests to verify new logic works. Tested using one of the Levine URLs.


