### PR TITLE
Handle RPA Record Creation Post-Processing Asynchronously

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -296,6 +296,18 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         return postResult;
     }
 
+    /**
+     * Evaluates the blacklist status of the given UserInfoWrapper.
+     * 
+     * Given a UserInfoWrapper, this method will evaluate the blacklist status
+     * of the user's email and country. If either the email or country is
+     * blacklisted, the method will return a string indicating the reason for
+     * the rejection. Otherwise, an empty string will be returned.
+     * 
+     * @param wrapper the UserInfoWrapper to evaluate
+     * @return a string indicating the reason for rejection, or an empty string
+     *         if the user is not blacklisted
+     */
     private String evaluateBlacklistStatus(UserInfoWrapper wrapper) {
         String email = wrapper.getUserInfo().getEmail();
         String country = wrapper.getUserInfo().getCountry();
@@ -399,6 +411,12 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     }
     
     
+    /**
+     * Builds the URL used to create a record in the Salesforce database.
+     * 
+     * @return the URL used to create a record in the Salesforce database.
+     * @throws RequestProcessingException if there is an error while building the URL.
+     */
     private String buildCreateRecordUrl() throws RequestProcessingException {
         try {
             String createRecordUri = getConfig().getSalesforceEndpoints().get(CREATE_RECORD_ENDPOINT_KEY);
@@ -411,6 +429,14 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         }
     }
 
+    /**
+     * Performs a POST request to the Salesforce service to create a new record.
+     * 
+     * @param url    the URL of the Salesforce endpoint to post to
+     * @param payload the JSON payload to send in the request body
+     * @return a RecordCreationResult containing the newly created record and the HTTP status code
+     * @throws RequestProcessingException if there is an error while performing the request
+     */
     private RecordCreationResult postToSalesforce(String url, String payload) throws RequestProcessingException {
         HttpURLConnection connection = null;
         try {
@@ -473,6 +499,12 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         return baseUrl + datasetId;
     }
 
+    /**
+     * Retrieves the metadata for the given datasetId in JSON format.
+     *
+     * @param datasetUrl the URL to retrieve the dataset metadata from
+     * @return the JSON metadata for the dataset, or null if the request fails
+     */
     private JsonNode fetchDatasetMetadata(String datasetUrl) {
         HttpURLConnection connection = null; 
         try {
@@ -499,6 +531,17 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     }
     
 
+    /**
+     * Check if a dataset is pre-approved.  This is done by examining the
+     * metadata for the dataset and looking for a component with type
+     * "nrdp:RestrictedAccessPage" and an accessProfile with type "rpa:rp0".
+     * If such a component is found, the method returns true, indicating the
+     * dataset is pre-approved.  Otherwise, it returns false.
+     * 
+     * @param metadata the JSON metadata for the dataset
+     * @param datasetId the dataset ID
+     * @return true if the dataset is pre-approved, false otherwise
+     */
     private boolean checkForPreApproval(JsonNode metadata, String datasetId) {
         JsonNode components = metadata.path("components");
         for (JsonNode component : components) {

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -260,16 +260,18 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     }
 
     /**
-     * Creates a new record in Salesforce using the information from the provided UserInfoWrapper object.
-     *
-     * This method builds a URL to create a record in Salesforce using a configuration endpoint.
-     * It prepares the request payload from the UserInfoWrapper object and sends a POST request
-     * to Salesforce. The response is parsed into a RecordWrapper object, which is returned.
-     *
-     * @param userInfoWrapper       The UserInfoWrapper object containing the data to create the new record.
-     * @return RecordWrapper        The RecordWrapper object containing the newly created record.
-     * @throws InvalidRequestException   If the request is invalid or incomplete.
-     * @throws RequestProcessingException If an error occurs during request processing, including URL creation, serialization, or communication errors.
+     * Creates a new record in the Salesforce database based on the provided user information.
+     * 
+     * This method will first validate the user information against the blacklist. If the user is on the
+     * blacklist, the record will be marked as rejected. Otherwise, the record will be created in
+     * Salesforce. The method will then return the result of the record creation, including the
+     * HTTP status code and the newly created record data.
+     * 
+     * @param userInfoWrapper the user information and record data for the new record
+     * @return the result of the record creation, including the HTTP status code and the newly
+     *         created record data
+     * @throws InvalidRequestException if the request payload is invalid
+     * @throws RequestProcessingException if there is an error while processing the request
      */
     @Override
     public RecordCreationResult createRecord(UserInfoWrapper userInfoWrapper)

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandler.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandler.java
@@ -9,43 +9,63 @@ import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
 import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
 
 /**
- * An interface for handling requests to manage records. This includes operations
- * such as creating, retrieving, and updating records. Implementations of this interface
- * are responsible for the interaction with a data source to perform these operations.
+ * An interface for handling requests to manage records. This includes
+ * operations
+ * such as creating, retrieving, and updating records. Implementations of this
+ * interface
+ * are responsible for the interaction with a data source to perform these
+ * operations.
  */
 public interface RPARequestHandler {
 
-    /**
-     * Updates the status of a record by ID.
-     * @param recordId the ID of the record to update
-     * @param status the new status for the record
-     * @return the updated record status
-     * @throws RecordNotFoundException if the record is not found
-     * @throws InvalidRequestException if the request payload is invalid
-     * @throws RequestProcessingException if there is an error while processing the request
-     */
-    RecordStatus updateRecord(String recordId, String status, String smeId) throws RecordNotFoundException, InvalidRequestException
-            , RequestProcessingException;
+        /**
+         * Updates the status of a record by ID.
+         * 
+         * @param recordId the ID of the record to update
+         * @param status   the new status for the record
+         * @return the updated record status
+         * @throws RecordNotFoundException    if the record is not found
+         * @throws InvalidRequestException    if the request payload is invalid
+         * @throws RequestProcessingException if there is an error while processing the
+         *                                    request
+         */
+        RecordStatus updateRecord(String recordId, String status, String smeId)
+                        throws RecordNotFoundException, InvalidRequestException, RequestProcessingException;
 
-    /**
-     * Gets a record by ID.
-     * @param recordId the ID of the record to get
-     * @return the record data
-     * @throws RecordNotFoundException if the record is not found
-     * @throws RequestProcessingException if there is an error while processing the request
-     */
-    RecordWrapper getRecord(String record) throws RecordNotFoundException, RequestProcessingException;
+        /**
+         * Gets a record by ID.
+         * 
+         * @param recordId the ID of the record to get
+         * @return the record data
+         * @throws RecordNotFoundException    if the record is not found
+         * @throws RequestProcessingException if there is an error while processing the
+         *                                    request
+         */
+        RecordWrapper getRecord(String record) throws RecordNotFoundException, RequestProcessingException;
 
-    /**
-     * Creates a new record for the specified user.
-     *
-     * @param userInfoWrapper     the user info and record data for the new record
-     * @param authorizationHeader
-     * @return the newly created record data
-     * @throws InvalidRequestException    if the request payload is invalid
-     * @throws RequestProcessingException if there is an error while processing the request
-     */
-    RecordWrapper createRecord(UserInfoWrapper userInfoWrapper) throws InvalidRequestException,
-            RequestProcessingException, RecaptchaVerificationFailedException;
+        /**
+         * Creates a new record for the specified user.
+         *
+         * @param userInfoWrapper     the user info and record data for the new record
+         * @param authorizationHeader
+         * @return the newly created record data
+         * @throws InvalidRequestException    if the request payload is invalid
+         * @throws RequestProcessingException if there is an error while processing the
+         *                                    request
+         */
+        RecordCreationResult createRecord(UserInfoWrapper userInfoWrapper) throws InvalidRequestException,
+                        RequestProcessingException, RecaptchaVerificationFailedException;
+
+        /**
+         * Handles the post-processing of a record creation.
+         *
+         * @param wrapper The RecordWrapper containing the record and its details.
+         * @param input   The UserInfoWrapper containing the original input data used to create the
+         *                record.
+         * @param code    The HTTP status code returned by the record creation request.
+         * @throws RequestProcessingException If an error occurs during post-processing.
+         */
+        public void handleAfterRecordCreation(RecordWrapper wrapper, UserInfoWrapper input, int code)
+                        throws RequestProcessingException;
 
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RecordCreationResult.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RecordCreationResult.java
@@ -1,0 +1,16 @@
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
+
+public class RecordCreationResult {
+    private final RecordWrapper recordWrapper;
+    private final int statusCode;
+
+    public RecordCreationResult(RecordWrapper wrapper, int code) {
+        this.recordWrapper = wrapper;
+        this.statusCode = code;
+    }
+
+    public RecordWrapper getRecordWrapper() { return recordWrapper; }
+    public int getStatusCode() { return statusCode; }
+}

--- a/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
@@ -1,0 +1,43 @@
+package gov.nist.oar.distrib.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+
+import gov.nist.oar.distrib.service.rpa.RPARequestHandler;
+import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
+import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
+import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
+
+public class RPAAsyncExecutor {
+
+    private RPARequestHandler handler = null;
+    /**
+     * Logger for this class.
+     */
+    private final static Logger LOGGER = LoggerFactory.getLogger(RPAAsyncExecutor.class);
+
+    public RPAAsyncExecutor(RPARequestHandler handler) {
+        this.handler = handler;
+    }
+
+    /**
+     * Handle the post-processing of a record creation asynchronously. This
+     * method does not throw any exceptions; rather, it logs any errors and
+     * continues.
+     * 
+     * @param wrapper The RecordWrapper containing the record and its
+     *                details.
+     * @param input   The UserInfoWrapper containing the original input data
+     *                used to create the record.
+     */
+    @Async
+    public void handleAfterRecordCreationAsync(RecordWrapper wrapper, UserInfoWrapper input, int code) {
+        try {
+            handler.handleAfterRecordCreation(wrapper, input, code);
+        } catch (RequestProcessingException e) {
+            LOGGER.error("Async post-processing failed for record ID {}: {}", wrapper.getRecord().getId(),
+                    e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
@@ -704,8 +704,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         // - The "Approved" status followed by a date-time in ISO 8601 format.
         // - An email address.
         // - A random ID (composed of word characters including underscore, alphanumeric, and possibly -) at the end.
-        String expectedFormat = "Approved_\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3,6}Z_[\\w.-]+@[\\w.-]+\\.\\w+_\\w+";
-        System.out.println("Actual value: " + payloadObject.get("Approval_Status__c"));
+        String expectedFormat = "Approved_\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3,9}Z_[\\w.-]+@[\\w.-]+\\.\\w+_\\w+"; //  d{3,9} -- up to 9 digits to include nanoseconds
         assertTrue(payloadObject.get("Approval_Status__c").toString().matches(expectedFormat));
     }
 

--- a/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
@@ -1,33 +1,17 @@
 package gov.nist.oar.distrib.service.rpa;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nist.oar.distrib.service.RPACachingService;
-import gov.nist.oar.distrib.service.rpa.exceptions.InvalidRequestException;
-import gov.nist.oar.distrib.service.rpa.exceptions.RecordNotFoundException;
-import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
-import gov.nist.oar.distrib.service.rpa.model.JWTToken;
-import gov.nist.oar.distrib.service.rpa.model.Record;
-import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
-import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
-import gov.nist.oar.distrib.service.rpa.model.UserInfo;
-import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
-import gov.nist.oar.distrib.web.RPAConfiguration;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnitRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -41,19 +25,35 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nist.oar.distrib.service.RPACachingService;
+import gov.nist.oar.distrib.service.rpa.exceptions.InvalidRequestException;
+import gov.nist.oar.distrib.service.rpa.exceptions.RecordNotFoundException;
+import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
+import gov.nist.oar.distrib.service.rpa.model.JWTToken;
+import gov.nist.oar.distrib.service.rpa.model.Record;
+import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
+import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
+import gov.nist.oar.distrib.service.rpa.model.UserInfo;
+import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
+import gov.nist.oar.distrib.web.RPAConfiguration;
 
 /**
  * This class contains unit tests for the {@link HttpURLConnectionRPARequestHandlerService} class.
@@ -87,7 +87,7 @@ import static org.mockito.Mockito.when;
  * Note: All tests should pass if the service is working correctly.
  */
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpURLConnectionRPARequestHandlerServiceTest {
 
     private static final String TEST_ACCESS_TOKEN = "test_access_token";
@@ -99,14 +99,14 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
             "\"Test Product\",\"subject\":\"1234567890\",\"description\":\"Test Product Description\"}}}";
 
     private static final String RECAPTCHA_RESPONSE = "recaptcha_response";
-    @Mock
+    @Mock(lenient = true)
     private RPAConfiguration rpaConfiguration;
     @Mock
     private HttpURLConnection mockConnection;
 
     @Mock
     private CloseableHttpClient mockHttpClient;
-    @Mock
+    @Mock(lenient = true)
     JWTHelper mockJwtHelper;
     @Mock
     RecaptchaHelper recaptchaHelper;
@@ -127,9 +127,8 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         put("update-record-endpoint", "/records/update");
     }};
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         service = spy(new HttpURLConnectionRPARequestHandlerService(rpaConfiguration, rpaCachingService));
         service.setJWTHelper(mockJwtHelper);
         service.setRecaptchaHelper(recaptchaHelper);
@@ -138,9 +137,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         service.seRPADatasetCacher(rpaDatasetCacher);
         service.setHttpClient(mockHttpClient);
 
-        // Set up mock behavior for rpaConfiguration
-        when(rpaConfiguration.getBaseDownloadUrl()).thenReturn("https://data.nist.gov/od/ds/");
-
+        
         // Set up mock behavior for mockJwtHelper
         testToken = new JWTToken(TEST_ACCESS_TOKEN, TEST_INSTANCE_URL);
         when(mockJwtHelper.getToken()).thenReturn(testToken);
@@ -250,8 +247,11 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
     @Test
     public void testCreateRecord_success()
             throws InvalidRequestException, IOException {
+        // Set up mock behavior for rpaConfiguration
+        when(rpaConfiguration.getBaseDownloadUrl()).thenReturn("https://data.nist.gov/od/ds/");
         // Arrange
-        // Mock the RPAConfiguration to return non-blacklisted email strings and countries
+        // Mock the RPAConfiguration to return non-blacklisted email strings and
+        // countries
         when(rpaConfiguration.getDisallowedEmails()).thenReturn(Arrays.asList("@disallowed\\.com$"));
         when(rpaConfiguration.getDisallowedCountries()).thenReturn(Arrays.asList("Disallowed Country"));
 
@@ -291,7 +291,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         );
 
         // Act
-        RecordWrapper actualRecord = service.createRecord(userInfoWrapper);
+        RecordCreationResult result = service.createRecord(userInfoWrapper);
+        RecordWrapper actualRecord = result.getRecordWrapper();
+
 
         // Assert
         assertEquals(actualRecord.getRecord().getId(), testRecordWrapper.getRecord().getId());
@@ -313,10 +315,6 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
 
         // Verify connection was closed
         verify(mockConnection).disconnect();
-
-        // Verify that onRecordCreationSuccess is called for non-blacklisted records
-        verify(recordResponseHandler, times(1)).onRecordCreationSuccess(any());
-
     }
 
     @Test
@@ -359,7 +357,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         when(mockConnection.getURL()).thenReturn(url);
 
         // Act
-        RecordWrapper actualRecord = service.createRecord(userInfoWrapper);
+        RecordCreationResult result = service.createRecord(userInfoWrapper);
+        RecordWrapper actualRecord = result.getRecordWrapper();
+
 
         // Assert
         assertEquals(actualRecord.getRecord().getId(), testRecordWrapper.getRecord().getId());
@@ -424,7 +424,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
         // Act
-        RecordWrapper actualRecord = service.createRecord(userInfoWrapper);
+        RecordCreationResult result = service.createRecord(userInfoWrapper);
+        RecordWrapper actualRecord = result.getRecordWrapper();
+
 
         // Assert
         assertEquals("rejected", actualRecord.getRecord().getUserInfo().getApprovalStatus());
@@ -438,7 +440,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
     public void testCreateRecord_withAuthorizedUser_shouldSucceed()
             throws InvalidRequestException, IOException {
         // Recaptcha stubbings ar no longer needed here since we skip verification
-
+        // Set up mock behavior for rpaConfiguration
+        when(rpaConfiguration.getBaseDownloadUrl()).thenReturn("https://data.nist.gov/od/ds/");
+        
         // Set up mock behavior for mockConnection
         // Set expected dummy response
         String expectedResponseData = "{\"record\":{\"id\":\"5003R000003ErErQAK\","
@@ -474,7 +478,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         );
 
         // Act
-        RecordWrapper actualRecord = service.createRecord(userInfoWrapper);
+        RecordCreationResult result = service.createRecord(userInfoWrapper);
+        RecordWrapper actualRecord = result.getRecordWrapper();
+
 
         // Assert
         assertEquals(actualRecord.getRecord().getId(), testRecordWrapper.getRecord().getId());
@@ -501,7 +507,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
     public void testCreateRecord_with_NON_AuthorizedUser_shouldSucceed()
             throws InvalidRequestException, IOException {
         // Arrange
-
+        // Set up mock behavior for rpaConfiguration
+        when(rpaConfiguration.getBaseDownloadUrl()).thenReturn("https://data.nist.gov/od/ds/");
+            
         // Set up mock behavior for mockConnection
         // Set expected dummy response
         String expectedResponseData = "{\"record\":{\"id\":\"5003R000003ErErQAK\","
@@ -537,7 +545,8 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         );
 
         // Act
-        RecordWrapper actualRecord = service.createRecord(userInfoWrapper);
+        RecordCreationResult result = service.createRecord(userInfoWrapper);
+        RecordWrapper actualRecord = result.getRecordWrapper();
 
         // Assert
         assertEquals(actualRecord.getRecord().getId(), testRecordWrapper.getRecord().getId());
@@ -581,7 +590,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
     public void testCreateRecord_failure_badRequest()
             throws IOException {
         // Arrange
-
+        // Set up mock behavior for rpaConfiguration
+        when(rpaConfiguration.getBaseDownloadUrl()).thenReturn("https://data.nist.gov/od/ds/");
+        
         // Set up mock behavior for mockConnection
         // Here the dummy record doesn't matter since we are expecting an exception to be thrown
         // Create a mock output stream for the connection
@@ -693,7 +704,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         // - The "Approved" status followed by a date-time in ISO 8601 format.
         // - An email address.
         // - A random ID (composed of word characters including underscore, alphanumeric, and possibly -) at the end.
-        String expectedFormat = "Approved_\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z_[\\w.-]+@[\\w.-]+\\.\\w+_\\w+";
+        String expectedFormat = "Approved_\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3,6}Z_[\\w.-]+@[\\w.-]+\\.\\w+_\\w+";
         assertTrue(payloadObject.get("Approval_Status__c").toString().matches(expectedFormat));
 
     }

--- a/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
@@ -705,8 +705,8 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         // - An email address.
         // - A random ID (composed of word characters including underscore, alphanumeric, and possibly -) at the end.
         String expectedFormat = "Approved_\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3,6}Z_[\\w.-]+@[\\w.-]+\\.\\w+_\\w+";
+        System.out.println("Actual value: " + payloadObject.get("Approval_Status__c"));
         assertTrue(payloadObject.get("Approval_Status__c").toString().matches(expectedFormat));
-
     }
 
     /**

--- a/src/test/java/gov/nist/oar/distrib/web/CacheManagementControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/CacheManagementControllerTest.java
@@ -358,7 +358,7 @@ public class CacheManagementControllerTest {
     }
 
     @Test
-    public void testStartMonitor() throws ConfigurationException {
+    public void testStartMonitor() throws ConfigurationException, InterruptedException {
         JSONObject status = null;
         ResponseEntity<String> resp = null;
         HttpEntity<String> req = new HttpEntity<String>(null, headers);
@@ -393,12 +393,30 @@ public class CacheManagementControllerTest {
         resp = websvc.exchange(getBaseURL() + "/cache/monitor/running", HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
 
-        resp = websvc.exchange(getBaseURL() + "/cache/monitor/", HttpMethod.GET, req, String.class);
-        assertEquals(HttpStatus.OK, resp.getStatusCode());
-        status = new JSONObject(new JSONTokener(resp.getBody()));
-        assertTrue(0L < status.getLong("lastRan"));
-        assertNotEquals("(never)", status.getString("lastRanDate"));
-        assertFalse(status.getBoolean("running"), "Monitor failed to finish?");
+        // resp = websvc.exchange(getBaseURL() + "/cache/monitor/", HttpMethod.GET, req, String.class);
+        // assertEquals(HttpStatus.OK, resp.getStatusCode());
+        // status = new JSONObject(new JSONTokener(resp.getBody()));
+        // assertTrue(0L < status.getLong("lastRan"));
+        // assertNotEquals("(never)", status.getString("lastRanDate"));
+        // assertFalse(status.getBoolean("running"), "Monitor failed to finish?");
+        
+        resp = websvc.exchange(getBaseURL() + "/cache/monitor/running", HttpMethod.GET, req, String.class);
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+        // keep polling /cache/monitor/ until the job completes
+        int attempts = 0;
+        while (attempts++ < 10) {
+            resp = websvc.exchange(getBaseURL() + "/cache/monitor/", HttpMethod.GET, req, String.class);
+            assertEquals(HttpStatus.OK, resp.getStatusCode());
+
+            status = new JSONObject(resp.getBody());
+            if (!status.getBoolean("running")) {
+                assertTrue(status.getLong("lastRan") > 0);
+                assertNotEquals("(never)", status.getString("lastRanDate"));
+                return;  // success
+            }
+            Thread.sleep(100);
+        }
+        fail("Monitor failed to finish?");
     }
 
 


### PR DESCRIPTION
This PR introduces asynchronous post-processing for RPA record creation in order to prevent the frontend clients from timing out due to long-running operations like caching, emails operations, and metadata resolution.

The problem is due to the backend's synchronous execution of record creation and post-processing logic (particularly email delivery and cache handling), which causes the client to wait for operations to complete. This PR solves this problem by introducing an `@Async` executor and integrating it into the request flow.

## Changes

**1. New Component `RPAAsyncExecutor`**
- A dedicated class that offloads `handleAfterRecordCreation()` logic to a background thread using Spring’s `@Async`.
- Logs errors instead of throwing them, since async tasks are detached from the request thread.

```java
@Async
public void handleAfterRecordCreationAsync(RecordWrapper wrapper, UserInfoWrapper input, int code) {
    try {
        handler.handleAfterRecordCreation(wrapper, input, code);
    } catch (RequestProcessingException e) {
        LOGGER.error("Async post-processing failed for record ID {}: {}", wrapper.getRecord().getId(),
                e.getMessage(), e);
    }
}
```

**2. Configuration**
- Added `@EnableAsync` to `NISTDistribServiceConfig`.
- Added a new bean for `RPAAsyncExecutor` in `NISTDistribServiceConfig`.

```java
@Bean
    public RPAAsyncExecutor getRPAAsyncExecutor(RPACachingServiceProvider rpaCachingServiceProvider,
            RPAServiceProvider rpaServiceProvider, S3Client s3)
            throws ConfigurationException, IOException, CacheManagementException {

        RPACachingService cachingService = rpaCachingServiceProvider.getRPACachingService(s3);
        RPARequestHandler handler = rpaServiceProvider.getRPARequestHandler(cachingService);
        return new RPAAsyncExecutor(handler);
    }
```

**3. Controller Update**
- `RPARequestHandlerController` now uses `RPAAsyncExecutor` for handling post-processing logic.

**4. Misc**
- Updated unit test in `CacheManagementControllerTest` with a polling loop that waits for the monitor to complete before asserting values. This avoids test results randomness.


## Testing
- Added test `testCreateRecord_TriggersAsyncPostProcessing()` to validate that `RPAAsyncExecutor` is called.
- Migrated tests under `HttpURLConnectionRPARequestHandlerServiceTest` to JUnit 5.
- oar-docker testing in progress.