### PR TITLE
Update Swagger/OpenAPI dependency and configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,8 +135,8 @@
         <!-- swagger docs -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.5.10</version>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,8 +41,10 @@ logging:
 
 springdoc:
   swagger-ui:
+    enabled: true
     tagsSorter: alpha
     path: /ds-api/swagger-ui.html
     disable-swagger-default-url: true
   api-docs:
+    enabled: true
     path: /ds-api/v3/api-docs


### PR DESCRIPTION
This PR updates the Swagger and OpenAPI setup.

### Changes

- **Dependency update**

For the integration between spring-boot and swagger-ui, the following library should be added to the project dependencies:

```xml
<dependency>
    <groupId>org.springdoc</groupId>
    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
    <version>2.6.0</version>
</dependency>
```

- **Config file `application.yml` update**

```yaml
springdoc:
  swagger-ui:
    enabled: true
    tagsSorter: alpha
    path: /ds-api/swagger-ui.html
    disable-swagger-default-url: true
  api-docs:
    enabled: true
    path: /ds-api/v3/api-docs
```

To disable the `api-docs` or `swagger-ui` endpoints, set the `enabled` property to `false`.

Source: [springdoc-openapi v2.8.11 docs](https://springdoc.org/)

### Testing
- Tested using oar-docker locally.
- Verified Swagger UI is available at `http://localhost/od/ds-api/swagger-ui.html`
- Verified OpenAPI JSON object available at `http://localhost/od/ds-api/v3/api-docs`