### PR TITLE
Bug fix: percent-decode paths before looking for files

### DIFF
--- a/src/main/java/gov/nist/oar/distrib/service/CacheEnabledFileDownloadService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/CacheEnabledFileDownloadService.java
@@ -285,7 +285,11 @@ public class CacheEnabledFileDownloadService implements FileDownloadService {
         if (cmgr != null) {
             try {
                 CacheObject out = cmgr.findObject(cacheid(dsid, filepath, version));
-                if (out != null && out.volume == null) out = null;
+                if (out != null && out.volume == null) {
+                    logger.debug("{}/{}: FYI: volume not specified for object found in cache",
+                                 dsid, filepath);
+                    out = null;
+                }
                 if (out != null)
                     return out;
             }

--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -644,6 +644,10 @@ public class DatasetAccessController {
             try {
                 CacheEnabledFileDownloadService cdls = (CacheEnabledFileDownloadService) downl;
                 CacheObject co = cdls.findCachedObject(dsid, filepath, version);
+                if (co == null)
+                    logger.debug("{}/{}: file not found in cache.", dsid, filepath);
+                else if (co.volume == null)
+                    logger.debug("{}/{}: No cache volume indicated for location.", dsid, filepath);
                 if (co != null && co.volume != null) {
                     URL redirect = cdls.redirectFor(co);
                     if (redirect != null) {
@@ -652,6 +656,7 @@ public class DatasetAccessController {
                         response.sendRedirect(redirect.toString()); // sends as 302 FOUND
                         return;
                     }
+                    logger.debug("{}/{}: streaming data from cache", dsid, filepath);
                     sh = cdls.openStreamFor(co);
                 }
             }
@@ -673,9 +678,11 @@ public class DatasetAccessController {
                 return; 
             }
 
-            if (sh == null)
+            if (sh == null) {
                 // fallback on direct download
                 sh = downl.getDataFile(dsid, filepath, version);
+                logger.debug("{}/{}: streaming data from long-term storage", dsid, filepath);
+            }
 
             /*
              * Need encodeDigest implementation that converts hex to base64

--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -432,7 +432,7 @@ public class DatasetAccessController {
         String requestPath = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
         String fullPath = requestPath.substring("/ds/".length() + dsid.length());  // e.g. folder/file.txt
 
-        if (fullPath.startsWith("/"))
+        if (fullPath.length() > 1 && fullPath.startsWith("/"))
             fullPath = fullPath.substring(1);
 
         String version = null;
@@ -641,10 +641,6 @@ public class DatasetAccessController {
             try {
                 CacheEnabledFileDownloadService cdls = (CacheEnabledFileDownloadService) downl;
                 CacheObject co = cdls.findCachedObject(dsid, filepath, version);
-                if (co == null)
-                    logger.debug("{}/{}: file not found in cache.", dsid, filepath);
-                else if (co.volume == null)
-                    logger.debug("{}/{}: No cache volume indicated for location.", dsid, filepath);
                 if (co != null && co.volume != null) {
                     URL redirect = cdls.redirectFor(co);
                     if (redirect != null) {
@@ -655,6 +651,10 @@ public class DatasetAccessController {
                     }
                     logger.debug("{}/{}: streaming data from cache", dsid, filepath);
                     sh = cdls.openStreamFor(co);
+                }
+                else {
+                    logger.debug("{}/{}: file not found in cache{}.", dsid, filepath,
+                                 (co != null) ? " (volume not set)" : "");
                 }
             }
             catch (ClassCastException ex) { /* fall back on direct read */ }

--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -428,12 +428,9 @@ public class DatasetAccessController {
                                Model model)
         throws ResourceNotFoundException, FileNotFoundException, DistributionException, IOException
     {
-
-        // Reconstruct raw path from the URI (after /ds/{dsid})
-        String requestURI = request.getRequestURI(); // e.g. /od/ds/mds1491/folder/
-        String contextPath = request.getContextPath(); // e.g. /od
-        String basePath = contextPath + "/ds/" + dsid;
-        String fullPath = requestURI.substring(basePath.length()); // e.g. folder/ or folder/file.txt
+        // NOTE:  requestPath will be percent-decoded which is required downstream
+        String requestPath = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+        String fullPath = requestPath.substring("/ds/".length() + dsid.length());  // e.g. folder/file.txt
 
         if (fullPath.startsWith("/"))
             fullPath = fullPath.substring(1);
@@ -449,7 +446,7 @@ public class DatasetAccessController {
         }
 
         // CASE 1: Request is for a directory → return HTML index page
-        if (requestURI.endsWith("/")) {
+        if (fullPath.endsWith("/")) {
             // Load nerdm.json
             JsonNode components = loadComponents(dsid);
 

--- a/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/DatasetAccessController.java
@@ -428,7 +428,7 @@ public class DatasetAccessController {
                                Model model)
         throws ResourceNotFoundException, FileNotFoundException, DistributionException, IOException
     {
-        // NOTE:  requestPath will be percent-decoded which is required downstream
+        // NOTE:  requestPath will be already percent-decoded which is required downstream
         String requestPath = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
         String fullPath = requestPath.substring("/ds/".length() + dsid.length());  // e.g. folder/file.txt
 


### PR DESCRIPTION
A bug was introduced into the `DatasetAccessController` (used to download files) when we added support for `rclone` downloads: URL paths were not getting %-decoded before the file path was searched for either in the cache or in archived bags.  Consequently, if the file contained anything %-encoded (e.g. a space), the service was responding that the file did not exist.  Percent-decoding was previously happening (quite mysteriously) via the use of the Spring web variable, `HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE`.  With the `rclone` support, it was replaced with more explicitly clear parsing but without the needed decoding.

This PR replaces the use of `HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE` (this time with heads-up comment) to allow one to download files with special characters in them again.

@elmiomar, the Spring web service testing method we use does not lend it self to testing %-encoded URLs easily.  Instead, I tested this on under oar-docker.  `rclone`-related unit tests are passing, but please double-check that I didn't break any of the `rclone` capabilities.