### PR TITLE
Feature: Async SME Approval Processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
         <sonar.jacoco.reportPath>${coverage.reports.dir}/jacoco-ut.exec</sonar.jacoco.reportPath>
         <sonar.jacoco.itReportPath>${coverage.reports.dir}/jacoco-it.exec</sonar.jacoco.itReportPath>
         <sonar.host.url>http://oardev3.nist.gov:9000/sonarqube</sonar.host.url>
+        <surefireArgLine></surefireArgLine>
+        <failsafeArgLine></failsafeArgLine>
     </properties>
 
     <dependencyManagement>
@@ -279,15 +281,16 @@
                 <artifactId>maven-surefire-plugin</artifactId>
 
                 <configuration>
-                    <argLine>${surefireArgLine}</argLine>
-                    <argLine>-Djava.io.tmpdir=${basedir}/target/tmp</argLine>
+                    <!-- Mockito inline needs instrumentation; preload Byte Buddy instead of relying on JDK self-attach. -->
+                    <argLine>${surefireArgLine} -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar -Djava.io.tmpdir=${project.build.directory}</argLine>
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
                     <systemPropertyVariables>
                         <basedir>${project.basedir}</basedir>
                     </systemPropertyVariables>
-                    <forkCount>0</forkCount>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
                     <systemPropertyVariables>
                         <conf.path>${user.home}/spm</conf.path>
                         <project.test.resourceDirectory>${project.basedir}/src/test/resources</project.test.resourceDirectory>

--- a/src/main/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheck.java
+++ b/src/main/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheck.java
@@ -21,7 +21,7 @@ public class CacheExpiryCheck implements CacheObjectCheck {
     /**
      * Checks if a cache object is expired and removes it from the cache if it is.
      * The method uses the {@code expires} metadata field to determine the expiration status.
-     * The expiration time is calculated based on the {@code LastModified} time plus the {@code expires} duration.
+     * The expiration time is stored as an absolute epoch millisecond value.
      * If the current time is past the calculated expiry time, the object is removed from the inventory database.
      *
      * @param co The cache object to check for expiration.
@@ -36,17 +36,11 @@ public class CacheExpiryCheck implements CacheObjectCheck {
         }
 
         if (co.hasMetadatum("expires")) {
-            long expiresDuration = co.getMetadatumLong("expires", -1L);
-            if (expiresDuration == -1L) {
+            long expiryTime = co.getMetadatumLong("expires", -1L);
+            if (expiryTime == -1L) {
                 throw new IntegrityException("Invalid 'expires' metadata value");
             }
 
-            long lastModified = co.getLastModified();
-            if (lastModified == -1L) {
-                throw new IntegrityException("CacheObject 'lastModified' time not available");
-            }
-
-            long expiryTime = lastModified + expiresDuration;
             long currentTime = Instant.now().toEpochMilli();
 
             // Check if the object is expired

--- a/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/RPACachingService.java
@@ -7,6 +7,7 @@ import gov.nist.oar.distrib.cachemgr.CacheObject;
 import gov.nist.oar.distrib.cachemgr.pdr.PDRDatasetCacheManager;
 import gov.nist.oar.distrib.cachemgr.pdr.PDRCacheManager;
 import gov.nist.oar.distrib.cachemgr.pdr.PDRCacheRoles;
+import gov.nist.oar.distrib.service.rpa.RPALogContext;
 import gov.nist.oar.distrib.service.rpa.exceptions.MetadataNotFoundException;
 import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
 import gov.nist.oar.distrib.web.RPAConfiguration;
@@ -61,7 +62,7 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
             throws CacheManagementException, ResourceNotFoundException, StorageVolumeException,
             IllegalArgumentException {
 
-        logger.debug("Request to cache dataset with ID=" + datasetID);
+        logger.info("RPA cache request started reqId={} dataset={}", RPALogContext.requestId(), datasetID);
 
         // this is to handle ark IDs
         String dsid = datasetID;
@@ -74,7 +75,6 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
             dsid = parts[2];
         }
 
-        logger.debug("Caching dataset with dsid=" + dsid);
         // append "rpa-" with the generated random ID
         String randomID = "rpa-" + generateRandomID(RANDOM_ID_LENGTH, true, true);
 
@@ -85,11 +85,8 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
 
         // cache dataset
         Set<String> files = this.pdrCacheManager.cacheDataset(dsid, version, true, prefs, randomID);
-        // Log the files
-        logger.debug("Cached files:");
-        for (String file : files) {
-            logger.debug("- " + file);
-        }
+        logger.info("RPA cache request completed reqId={} dataset={} fileCount={}",
+                RPALogContext.requestId(), datasetID, files.size());
         return randomID;
     }
 
@@ -102,7 +99,8 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
      */
     public Map<String, Object> retrieveMetadata(String randomID) throws CacheManagementException,
             MetadataNotFoundException, RequestProcessingException {
-        logger.debug("Requesting metadata for temporary ID=" + randomID);
+        logger.debug("RPA metadata retrieval started reqId={} randomIdPresent={}",
+                RPALogContext.requestId(), randomID != null);
         JSONArray metadata = new JSONArray();
         List<CacheObject> objects = this.pdrCacheManager.selectDatasetObjects(randomID,
                 this.pdrCacheManager.VOL_FOR_GET);
@@ -122,9 +120,8 @@ public class RPACachingService implements DataCachingService, PDRCacheRoles {
         JSONObject result = new JSONObject();
         result.put("randomId", randomID);
         result.put("metadata", metadata);
-        // Log the JSON object
-        logger.debug("Result:");
-        logger.debug(result.toString(4));
+        logger.debug("RPA metadata retrieval completed reqId={} metadataCount={}",
+                RPALogContext.requestId(), metadata.length());
         return result.toMap();
     }
 

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/EmailInfoProvider.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/EmailInfoProvider.java
@@ -7,6 +7,7 @@ import org.apache.commons.text.StringSubstitutor;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Locale;
@@ -21,7 +22,6 @@ import java.util.stream.Stream;
 public class EmailInfoProvider {
 
     private static final String DATE_PATTERN = "EEEE, MM/dd/yyyy 'at' hh:mm a z";
-    private static final int EXPIRATION_DAYS = 14;
     private final RPAConfiguration rpaConfiguration;
 
     /**
@@ -208,7 +208,7 @@ public class EmailInfoProvider {
      */
     private String getExpirationDate() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PATTERN, Locale.ENGLISH);
-        ZonedDateTime date = ZonedDateTime.now().plusDays(EXPIRATION_DAYS);
+        ZonedDateTime date = ZonedDateTime.now().plus(rpaConfiguration.getExpiresAfterMillis(), ChronoUnit.MILLIS);
         return formatter.format(date);
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -713,6 +713,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
         // Return result for async processing
         // Note: Email notifications and caching are handled asynchronously
+        record.getUserInfo().setApprovalStatus(approvalStatus);
         return new RecordUpdateResult(recordStatus, record, datasetId);
     }
 
@@ -755,6 +756,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
             if (randomId == null) {
                 LOGGER.error("Caching process returned a null randomId for dataset: {}", datasetId);
+                patchFailureStatus(record);
                 this.recordResponseHandler.onFailure(record);
                 return;
             }
@@ -763,6 +765,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
             String currentStatus = record.getUserInfo().getApprovalStatus();
             String finalStatus = updateApprovalStatusWithRandomId(currentStatus, randomId);
             patchRecordStatus(record.getId(), finalStatus);
+            record.getUserInfo().setApprovalStatus(finalStatus);
 
             // Send success email with download link
             this.recordResponseHandler.onRecordUpdateApproved(record, randomId);
@@ -770,7 +773,15 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
         } catch (Exception e) {
             LOGGER.error("Approval post-processing failed for record {}: {}", record.getId(), e.getMessage(), e);
-            // Send failure notification to user
+            if (randomId != null) {
+                try {
+                    this.rpaDatasetCacher.uncache(randomId);
+                } catch (Exception uncacheException) {
+                    LOGGER.error("Failed to uncache dataset after approval failure (random ID {}): {}",
+                            randomId, uncacheException.getMessage(), uncacheException);
+                }
+            }
+            patchFailureStatus(record);
             this.recordResponseHandler.onFailure(record);
         }
     }
@@ -799,6 +810,17 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         LOGGER.info("Decline post-processing completed for record: {}", record.getId());
     }
 
+    private void patchFailureStatus(Record record) {
+        String failureStatus = updateApprovalStatusPrefix(record.getUserInfo().getApprovalStatus(), "ApprovalFailed");
+        try {
+            patchRecordStatus(record.getId(), failureStatus);
+            record.getUserInfo().setApprovalStatus(failureStatus);
+        } catch (RequestProcessingException e) {
+            LOGGER.error("Failed to update approval failure status for record {}: {}",
+                    record.getId(), e.getMessage(), e);
+        }
+    }
+
     /**
      * Updates the approval status string to include the random ID.
      * Converts "ApprovalPending_timestamp_smeId" to "Approved_timestamp_smeId_randomId"
@@ -806,13 +828,20 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     private String updateApprovalStatusWithRandomId(String currentStatus, String randomId) {
         // Replace "ApprovalPending" with "Approved" and append randomId
         if (currentStatus != null && currentStatus.startsWith("ApprovalPending_")) {
-            return currentStatus.replace("ApprovalPending_", "Approved_") + "_" + randomId;
+            return updateApprovalStatusPrefix(currentStatus, "Approved") + "_" + randomId;
         }
         // Fallback: if already "Approved_", just append randomId
         if (currentStatus != null && currentStatus.startsWith("Approved_") && !currentStatus.contains("_" + randomId)) {
             return currentStatus + "_" + randomId;
         }
         return currentStatus;
+    }
+
+    private String updateApprovalStatusPrefix(String currentStatus, String newPrefix) {
+        if (currentStatus != null && currentStatus.contains("_")) {
+            return newPrefix + currentStatus.substring(currentStatus.indexOf("_"));
+        }
+        return newPrefix + "_" + Instant.now().toString();
     }
 
     /**

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -23,6 +23,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -209,7 +210,8 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         } catch (URISyntaxException e) {
             throw new RequestProcessingException("Error building URI: " + e.getMessage());
         }
-        LOGGER.debug("GET_RECORD_URL=" + url);
+        LOGGER.debug("RPA Salesforce record fetch started reqId={} recordId={} endpoint={}",
+                RPALogContext.requestId(), recordId, RPALogContext.safeUrl(url));
         // Create the HttpURLConnection and send the GET request
         RecordWrapper recordWrapper;
         HttpURLConnection connection = null;
@@ -231,24 +233,37 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
                     while ((line = in.readLine()) != null) {
                         response.append(line);
                     }
-                    LOGGER.debug("GET_RECORD_RESPONSE=" + response);
-                    // Handle the response
                     recordWrapper = new ObjectMapper().readValue(response.toString(), RecordWrapper.class);
+                    if (recordWrapper != null && recordWrapper.getRecord() != null) {
+                        RPALogContext.updateFromRecord(recordWrapper.getRecord());
+                        LOGGER.debug("RPA Salesforce record fetch completed reqId={} recordId={} caseNum={} approvalStatus={}",
+                                RPALogContext.requestId(),
+                                recordWrapper.getRecord().getId(),
+                                recordWrapper.getRecord().getCaseNum(),
+                                RPALogContext.summarizeApprovalStatus(
+                                        recordWrapper.getRecord().getUserInfo().getApprovalStatus()));
+                    }
                 }
             } else if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
                 // Handle the error HTTP_NOT_FOUND response
+                LOGGER.warn("RPA Salesforce record fetch returned not-found reqId={} recordId={}",
+                        RPALogContext.requestId(), recordId);
                 throw RecordNotFoundException.fromRecordId(recordId);
             } else {
                 // Handle any other error response
+                LOGGER.warn("RPA Salesforce record fetch failed reqId={} recordId={} statusCode={} message={}",
+                        RPALogContext.requestId(), recordId, responseCode, connection.getResponseMessage());
                 throw new RequestProcessingException("Error response from salesforce service: " + connection.getResponseMessage());
             }
         } catch (MalformedURLException e) {
             // Handle the URL Malformed error
-            LOGGER.debug("Invalid URL: " + e.getMessage());
+            LOGGER.error("RPA Salesforce record fetch failed reqId={} recordId={} reason=invalid-url message={}",
+                    RPALogContext.requestId(), recordId, e.getMessage());
             throw new RequestProcessingException("Invalid URL: " + e.getMessage());
         } catch (IOException e) {
             // Handle the I/O error
-            LOGGER.debug("Error sending GET request: " + e.getMessage());
+            LOGGER.error("RPA Salesforce record fetch failed reqId={} recordId={} message={}",
+                    RPALogContext.requestId(), recordId, e.getMessage());
             throw new RequestProcessingException("I/O error: " + e.getMessage());
         } finally {
             // Close the connection
@@ -296,7 +311,22 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         // 3. Call Salesforce
         RecordCreationResult postResult = postToSalesforce(url, payload);
         int statusCode = postResult.getStatusCode();
-        LOGGER.debug("CREATE_RECORD_STATUS_CODE=" + statusCode);
+        Record createdRecord = postResult.getRecordWrapper() != null ? postResult.getRecordWrapper().getRecord() : null;
+        if (createdRecord != null) {
+            RPALogContext.updateFromRecord(createdRecord);
+            LOGGER.info("RPA Salesforce record create completed reqId={} dataset={} recordId={} caseNum={} approvalStatus={} statusCode={}",
+                    RPALogContext.requestId(),
+                    createdRecord.getUserInfo().getSubject(),
+                    createdRecord.getId(),
+                    createdRecord.getCaseNum(),
+                    RPALogContext.summarizeApprovalStatus(createdRecord.getUserInfo().getApprovalStatus()),
+                    statusCode);
+        } else {
+            LOGGER.info("RPA Salesforce record create completed reqId={} dataset={} statusCode={}",
+                    RPALogContext.requestId(),
+                    userInfoWrapper.getUserInfo().getSubject(),
+                    statusCode);
+        }
 
         return postResult;
     }
@@ -318,25 +348,31 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         String country = wrapper.getUserInfo().getCountry();
         String datasetId = wrapper.getUserInfo().getSubject(); // Dataset ID comes from subject
 
-        LOGGER.debug("USER_EMAIL={}, USER_COUNTRY={}, DATASET_ID={}", email, country, datasetId);
+        LOGGER.debug("RPA blacklist check started reqId={} dataset={} emailDomain={} country={}",
+                RPALogContext.requestId(), datasetId, RPALogContext.emailDomain(email), country);
 
         RPAConfiguration.BlacklistConfig blacklist = rpaConfiguration.getBlacklists().get(datasetId);
 
         if (blacklist == null) {
-            LOGGER.info("No blacklist configured for dataset {}, access allowed.", datasetId);
+            LOGGER.info("RPA blacklist check passed reqId={} dataset={} ruleSet=none",
+                    RPALogContext.requestId(), datasetId);
             return ""; // Allow access if no blacklist defined
         }
 
         if (isEmailBlacklisted(email, blacklist.getDisallowedEmails())) {
-            LOGGER.warn("Email {} is blacklisted for dataset {}.", email, datasetId);
+            LOGGER.warn("RPA blacklist check blocked reqId={} dataset={} reason=email email={}",
+                    RPALogContext.requestId(), datasetId, RPALogContext.maskEmail(email));
             return "Email " + email + " is blacklisted for dataset " + datasetId + ".";
         }
 
         if (isCountryBlacklisted(country, blacklist.getDisallowedCountries())) {
-            LOGGER.warn("Country {} is blacklisted for dataset {}.", country, datasetId);
+            LOGGER.warn("RPA blacklist check blocked reqId={} dataset={} reason=country country={}",
+                    RPALogContext.requestId(), datasetId, country);
             return "Country " + country + " is blacklisted for dataset " + datasetId + ".";
         }
 
+        LOGGER.info("RPA blacklist check passed reqId={} dataset={} ruleSet=configured",
+                RPALogContext.requestId(), datasetId);
         return "";
     }
     
@@ -379,7 +415,10 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     private String preparePayloadOrFail(UserInfoWrapper wrapper) throws RequestProcessingException {
         try {
             String payload = prepareRequestPayload(wrapper);
-            LOGGER.debug("CREATE_RECORD_PAYLOAD={}", payload);
+            LOGGER.debug("RPA create-record payload prepared reqId={} dataset={} approvalStatus={} fields=userInfo",
+                    RPALogContext.requestId(),
+                    wrapper.getUserInfo().getSubject(),
+                    RPALogContext.summarizeApprovalStatus(wrapper.getUserInfo().getApprovalStatus()));
             return payload;
         } catch (JsonProcessingException e) {
             LOGGER.error("Error preparing payload: {}", e.getMessage());
@@ -421,7 +460,10 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         switch (status) {
             case RECORD_REJECTED_STATUS:
                 // Automatically rejected records (e.g., blacklisted) require no post-processing
-                LOGGER.info("Record auto-rejected; skipping post-processing.");
+                LOGGER.info("RPA post-create processing skipped reqId={} recordId={} dataset={} reason=auto-rejected",
+                        RPALogContext.requestId(),
+                        wrapper.getRecord().getId(),
+                        input.getUserInfo().getSubject());
                 break;
 
             case RECORD_PRE_APPROVED_STATUS:
@@ -432,16 +474,21 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
                     if (randomId == null) {
                         // Caching failed — notify user of failure
-                        LOGGER.warn("Failed to cache dataset '{}'; notifying user of processing failure.", datasetId);
+                        LOGGER.warn("RPA pre-approved cache failed reqId={} recordId={} dataset={} reason=null-cart-id",
+                                RPALogContext.requestId(), wrapper.getRecord().getId(), datasetId);
                         recordResponseHandler.onFailure(wrapper.getRecord());
                     } else {
                         // Caching succeeded — notify user of success and provide download link
+                        LOGGER.info("RPA pre-approved cache completed reqId={} recordId={} dataset={}",
+                                RPALogContext.requestId(), wrapper.getRecord().getId(), datasetId);
                         recordResponseHandler.onPreApprovedRecordCreationSuccess(wrapper.getRecord(), randomId);
                     }
 
                 } catch (Exception e) {
                     // Unexpected error during caching or metadata lookup — notify user
-                    LOGGER.error("Unexpected error while caching dataset or fetching metadata: {}", e.getMessage(), e);
+                    LOGGER.error("RPA pre-approved post-processing failed reqId={} recordId={} dataset={}: {}",
+                            RPALogContext.requestId(), wrapper.getRecord().getId(),
+                            input.getUserInfo().getSubject(), e.getMessage(), e);
                     recordResponseHandler.onFailure(wrapper.getRecord());
                 }
                 break;
@@ -502,17 +549,19 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
                     while ((line = in.readLine()) != null) {
                         response.append(line);
                     }
-                    LOGGER.debug("CREATE_RECORD_RESPONSE=" + response);
                     RecordWrapper recordWrapper =  new ObjectMapper().readValue(response.toString(), RecordWrapper.class);
                     return new RecordCreationResult(recordWrapper, responseCode);
 
                 }
             } else {
-                LOGGER.error("Salesforce returned error: " + connection.getResponseMessage());
+                LOGGER.error("RPA Salesforce record create failed reqId={} endpoint={} statusCode={} message={}",
+                        RPALogContext.requestId(), RPALogContext.safeUrl(url), responseCode, connection.getResponseMessage());
                 throw new RequestProcessingException("Error response from Salesforce service: " + connection.getResponseMessage());
             }
-    
+
         } catch (IOException e) {
+            LOGGER.error("RPA Salesforce record create failed reqId={} endpoint={} message={}",
+                    RPALogContext.requestId(), RPALogContext.safeUrl(url), e.getMessage());
             throw new RequestProcessingException("I/O error during POST to Salesforce: " + e.getMessage());
         } finally {
             if (connection != null) {
@@ -590,12 +639,14 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
             if (typeNode.isArray() && typeNode.toString().contains("nrdp:RestrictedAccessPage")) {
                 JsonNode accessProfile = component.path("pdr:accessProfile");
                 if (!accessProfile.isMissingNode() && "rpa:rp0".equals(accessProfile.path("@type").asText())) {
-                    LOGGER.info("Dataset (ID =" + datasetId + ")  is pre-approved.");
+                    LOGGER.info("RPA approval path selected reqId={} dataset={} mode=pre-approved",
+                            RPALogContext.requestId(), datasetId);
                     return true;
                 }
             }
         }
-        LOGGER.info("Dataset (ID =" + datasetId + ") requires SME approval.");
+        LOGGER.info("RPA approval path selected reqId={} dataset={} mode=sme",
+                RPALogContext.requestId(), datasetId);
         return false;
     }
     
@@ -650,6 +701,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         RecordStatus recordStatus;
         Record record = this.getRecord(recordId).getRecord();
         String datasetId = record.getUserInfo().getSubject();
+        String currentStatus = record.getUserInfo().getApprovalStatus();
 
         // Create a valid approval status based on input
         // For approvals, use interim "ApprovalPending" status (no random ID yet)
@@ -659,7 +711,6 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         // PATCH request payload
         // Approval_Status__c is how SF service expect the key
         String patchPayload = new JSONObject().put("Approval_Status__c", approvalStatus).toString();
-        LOGGER.debug("UPDATE_RECORD_PAYLOAD=" + patchPayload);
 
         // Get token
         JWTToken token = jwtHelper.getToken();
@@ -677,7 +728,10 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         } catch (URISyntaxException e) {
             throw new RequestProcessingException("Error building URI: " + e.getMessage());
         }
-        LOGGER.debug("UPDATE_RECORD_URL=" + url);
+        LOGGER.debug("RPA record status update started reqId={} recordId={} endpoint={} requestedAction={} previousStatus={} targetStatus={}",
+                RPALogContext.requestId(), recordId, RPALogContext.safeUrl(url), status,
+                RPALogContext.summarizeApprovalStatus(currentStatus),
+                RPALogContext.summarizeApprovalStatus(approvalStatus));
 
         // Send PATCH request
         try {
@@ -689,25 +743,30 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
             CloseableHttpResponse response = httpClient.execute(httpPatch);
             int statusCode = response.getStatusLine().getStatusCode();
-            LOGGER.debug("UPDATE_RECORD_STATUS_CODE=" + statusCode);
             if (statusCode == HttpStatus.SC_OK) { // If success
                 try (InputStream inputStream = response.getEntity().getContent()) {
                     String responseString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-                    LOGGER.debug("UPDATE_RECORD_RESPONSE=" + responseString);
                     // Handle the response
                     recordStatus = new ObjectMapper().readValue(responseString, RecordStatus.class);
+                    LOGGER.info("RPA record status updated reqId={} recordId={} caseNum={} dataset={} action={} previousStatus={} newStatus={}",
+                            RPALogContext.requestId(), recordId, record.getCaseNum(), datasetId, status,
+                            RPALogContext.summarizeApprovalStatus(currentStatus),
+                            RPALogContext.summarizeApprovalStatus(approvalStatus));
                 }
             } else if (statusCode == HttpStatus.SC_BAD_REQUEST) { // If bad request
-                LOGGER.debug("Invalid request: " + response.getStatusLine().getReasonPhrase());
+                LOGGER.warn("RPA record status update rejected reqId={} recordId={} statusCode={} message={}",
+                        RPALogContext.requestId(), recordId, statusCode, response.getStatusLine().getReasonPhrase());
                 throw new InvalidRequestException("Invalid request: " + response.getStatusLine().getReasonPhrase());
             } else {
                 // Handle any other error response
-                LOGGER.debug("Error response from Salesforce service: " + response.getStatusLine().getReasonPhrase());
+                LOGGER.error("RPA record status update failed reqId={} recordId={} statusCode={} message={}",
+                        RPALogContext.requestId(), recordId, statusCode, response.getStatusLine().getReasonPhrase());
                 throw new RequestProcessingException("Error response from Salesforce service: " + response.getStatusLine().getReasonPhrase());
             }
         } catch (IOException e) {
             // Handle the I/O error
-            LOGGER.debug("Error sending PATCH request: " + e.getMessage());
+            LOGGER.error("RPA record status update failed reqId={} recordId={} message={}",
+                    RPALogContext.requestId(), recordId, e.getMessage());
             throw new RequestProcessingException("I/O error: " + e.getMessage());
         }
 
@@ -748,37 +807,65 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
     private void handleApprovalPostProcessing(Record record, String datasetId)
             throws RequestProcessingException {
         String randomId = null;
+        long startedAt = System.currentTimeMillis();
 
         try {
             // Cache the dataset
-            LOGGER.info("Starting async caching for dataset: {}", datasetId);
+            LOGGER.info("RPA approval post-processing started reqId={} recordId={} dataset={} stage=caching",
+                    RPALogContext.requestId(), record.getId(), datasetId);
+            long cacheStartedAt = System.currentTimeMillis();
             randomId = this.rpaDatasetCacher.cache(datasetId);
+            long cacheElapsedMs = System.currentTimeMillis() - cacheStartedAt;
 
             if (randomId == null) {
-                LOGGER.error("Caching process returned a null randomId for dataset: {}", datasetId);
+                LOGGER.error("RPA approval post-processing failed reqId={} recordId={} dataset={} reason=null-cart-id",
+                        RPALogContext.requestId(), record.getId(), datasetId);
                 patchFailureStatus(record);
                 this.recordResponseHandler.onFailure(record);
                 return;
             }
+            LOGGER.info("RPA approval cache completed reqId={} recordId={} dataset={} cartId={} elapsedMs={}",
+                    RPALogContext.requestId(), record.getId(), datasetId, randomId, cacheElapsedMs);
 
             // Update Salesforce with final status including randomId
             String currentStatus = record.getUserInfo().getApprovalStatus();
             String finalStatus = updateApprovalStatusWithRandomId(currentStatus, randomId);
+            LOGGER.info(
+                    "RPA approval finalization started reqId={} recordId={} dataset={} currentStatus={} targetStatus={} cartId={}",
+                    RPALogContext.requestId(),
+                    record.getId(),
+                    datasetId,
+                    RPALogContext.summarizeApprovalStatus(currentStatus),
+                    RPALogContext.summarizeApprovalStatus(finalStatus),
+                    randomId);
             patchRecordStatus(record.getId(), finalStatus);
+            LOGGER.info("RPA approval finalization patch succeeded reqId={} recordId={} dataset={} targetStatus={}",
+                    RPALogContext.requestId(), record.getId(), datasetId,
+                    RPALogContext.summarizeApprovalStatus(finalStatus));
             record.getUserInfo().setApprovalStatus(finalStatus);
 
             // Send success email with download link
             this.recordResponseHandler.onRecordUpdateApproved(record, randomId);
-            LOGGER.info("Approval post-processing completed for record: {}", record.getId());
+            LOGGER.info("RPA approval post-processing completed reqId={} recordId={} dataset={} finalStatus={} totalElapsedMs={}",
+                    RPALogContext.requestId(), record.getId(), datasetId,
+                    RPALogContext.summarizeApprovalStatus(finalStatus),
+                    System.currentTimeMillis() - startedAt);
 
         } catch (Exception e) {
-            LOGGER.error("Approval post-processing failed for record {}: {}", record.getId(), e.getMessage(), e);
+            LOGGER.error("RPA approval post-processing failed reqId={} recordId={} dataset={} elapsedMs={}: {}",
+                    RPALogContext.requestId(), record.getId(), datasetId,
+                    System.currentTimeMillis() - startedAt, e.getMessage(), e);
             if (randomId != null) {
                 try {
+                    LOGGER.warn("RPA approval cleanup started reqId={} recordId={} dataset={} cartId={}",
+                            RPALogContext.requestId(), record.getId(), datasetId, randomId);
                     this.rpaDatasetCacher.uncache(randomId);
+                    LOGGER.warn("RPA approval cleanup completed reqId={} recordId={} dataset={} cartId={}",
+                            RPALogContext.requestId(), record.getId(), datasetId, randomId);
                 } catch (Exception uncacheException) {
-                    LOGGER.error("Failed to uncache dataset after approval failure (random ID {}): {}",
-                            randomId, uncacheException.getMessage(), uncacheException);
+                    LOGGER.error("RPA approval cleanup failed reqId={} recordId={} dataset={} stage=uncache: {}",
+                            RPALogContext.requestId(), record.getId(), datasetId,
+                            uncacheException.getMessage(), uncacheException);
                 }
             }
             patchFailureStatus(record);
@@ -797,17 +884,21 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
 
         if (randomId != null) {
             try {
-                LOGGER.info("Uncaching dataset with random ID: {}", randomId);
+                LOGGER.info("RPA decline post-processing started reqId={} recordId={} stage=uncache",
+                        RPALogContext.requestId(), record.getId());
                 this.rpaDatasetCacher.uncache(randomId);
             } catch (Exception e) {
                 // Log but don't fail - the decline should still succeed
-                LOGGER.error("Failed to uncache dataset with ID {}: {}", randomId, e.getMessage(), e);
+                LOGGER.error("RPA decline cleanup failed reqId={} recordId={}: {}",
+                        RPALogContext.requestId(), record.getId(), e.getMessage(), e);
             }
         }
 
         // Send decline notification
         this.recordResponseHandler.onRecordUpdateDeclined(record);
-        LOGGER.info("Decline post-processing completed for record: {}", record.getId());
+        LOGGER.info("RPA decline post-processing completed reqId={} recordId={} finalStatus={}",
+                RPALogContext.requestId(), record.getId(),
+                RPALogContext.summarizeApprovalStatus(record.getUserInfo().getApprovalStatus()));
     }
 
     private void patchFailureStatus(Record record) {
@@ -849,7 +940,6 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
      */
     private void patchRecordStatus(String recordId, String approvalStatus) throws RequestProcessingException {
         String patchPayload = new JSONObject().put("Approval_Status__c", approvalStatus).toString();
-        LOGGER.debug("PATCH_RECORD_STATUS_PAYLOAD=" + patchPayload);
 
         JWTToken token = jwtHelper.getToken();
         String updateRecordUri = getConfig().getSalesforceEndpoints().get(UPDATE_RECORD_ENDPOINT_KEY);
@@ -871,14 +961,35 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
             HttpEntity httpEntity = new StringEntity(patchPayload, ContentType.APPLICATION_JSON);
             httpPatch.setEntity(httpEntity);
 
-            CloseableHttpResponse response = httpClient.execute(httpPatch);
-            int statusCode = response.getStatusLine().getStatusCode();
-            LOGGER.debug("PATCH_RECORD_STATUS_CODE=" + statusCode);
+            long executeStartedAt = System.currentTimeMillis();
+            LOGGER.info("RPA record status patch executing reqId={} recordId={} endpoint={} targetStatus={}",
+                    RPALogContext.requestId(), recordId, RPALogContext.safeUrl(url),
+                    RPALogContext.summarizeApprovalStatus(approvalStatus));
 
-            if (statusCode != HttpStatus.SC_OK) {
-                throw new RequestProcessingException("Failed to update record status: " + response.getStatusLine().getReasonPhrase());
+            try (CloseableHttpResponse response = httpClient.execute(httpPatch)) {
+                long executeElapsedMs = System.currentTimeMillis() - executeStartedAt;
+                int statusCode = response.getStatusLine().getStatusCode();
+                LOGGER.info("RPA record status patch returned reqId={} recordId={} statusCode={} elapsedMs={} targetStatus={}",
+                        RPALogContext.requestId(), recordId, statusCode, executeElapsedMs,
+                        RPALogContext.summarizeApprovalStatus(approvalStatus));
+
+                if (statusCode != HttpStatus.SC_OK) {
+                    String responseBody = response.getEntity() != null ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8) : "";
+                    LOGGER.error(
+                            "RPA record status patch failed reqId={} recordId={} statusCode={} reason={} targetStatus={} responseBody={}",
+                            RPALogContext.requestId(),
+                            recordId,
+                            statusCode,
+                            response.getStatusLine().getReasonPhrase(),
+                            RPALogContext.summarizeApprovalStatus(approvalStatus),
+                            responseBody);
+                    throw new RequestProcessingException("Failed to update record status: " + response.getStatusLine().getReasonPhrase());
+                }
             }
         } catch (IOException e) {
+            LOGGER.error("RPA record status patch I/O failure reqId={} recordId={} endpoint={} targetStatus={}: {}",
+                    RPALogContext.requestId(), recordId, RPALogContext.safeUrl(url),
+                    RPALogContext.summarizeApprovalStatus(approvalStatus), e.getMessage(), e);
             throw new RequestProcessingException("I/O error updating record status: " + e.getMessage());
         }
     }

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerService.java
@@ -294,12 +294,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         // 1. Blacklist validation
         String rejectionReason = evaluateBlacklistStatus(userInfoWrapper);
         if (!rejectionReason.isEmpty()) {
-            try {
-                updateApprovalStatus(userInfoWrapper);
-            } catch (RequestProcessingException e) {
-                LOGGER.error("Metadata lookup failed: {}", e.getMessage());
-                throw e;  // Stop record creation
-            }
+            markAsRejected(userInfoWrapper, rejectionReason);
         } else {
             updateApprovalStatus(userInfoWrapper);
         }
@@ -385,7 +380,8 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
      */
     private void markAsRejected(UserInfoWrapper wrapper, String reason) {
         wrapper.getUserInfo().setApprovalStatus(RECORD_REJECTED_STATUS);
-        String updatedDesc = wrapper.getUserInfo().getDescription() +
+        String description = wrapper.getUserInfo().getDescription();
+        String updatedDesc = (description == null ? "" : description) +
                 "\nThis record was automatically rejected. Reason: " + reason;
         wrapper.getUserInfo().setDescription(updatedDesc);
     }
@@ -680,7 +676,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
      * <p>
      * This method handles the approval or decline of a record. For approvals, it sets an interim
      * "ApprovalPending" status and returns immediately. The actual caching and final status update
-     * happen asynchronously via {@link #handleAfterRecordUpdate(Record, String, String)}.
+     * happen asynchronously via {@link #handleAfterRecordUpdate(Record, String, String, String)}.
      * </p>
      * <p>
      * For declines, the status is updated directly without caching.
@@ -773,7 +769,7 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
         // Return result for async processing
         // Note: Email notifications and caching are handled asynchronously
         record.getUserInfo().setApprovalStatus(approvalStatus);
-        return new RecordUpdateResult(recordStatus, record, datasetId);
+        return new RecordUpdateResult(recordStatus, record, datasetId, currentStatus);
     }
 
     /**
@@ -790,13 +786,13 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
      * @throws RequestProcessingException if an error occurs during post-processing
      */
     @Override
-    public void handleAfterRecordUpdate(Record record, String status, String datasetId)
+    public void handleAfterRecordUpdate(Record record, String status, String datasetId, String previousApprovalStatus)
             throws RequestProcessingException {
 
         if (RECORD_APPROVED_STATUS.equalsIgnoreCase(status)) {
             handleApprovalPostProcessing(record, datasetId);
         } else if (RECORD_DECLINED_STATUS.equalsIgnoreCase(status)) {
-            handleDeclinePostProcessing(record);
+            handleDeclinePostProcessing(record, previousApprovalStatus);
         }
     }
 
@@ -877,15 +873,18 @@ public class HttpURLConnectionRPARequestHandlerService implements RPARequestHand
      * Handles the async post-processing for a decline.
      * Uncaches the dataset if previously approved, and sends decline notification.
      */
-    private void handleDeclinePostProcessing(Record record) {
+    private void handleDeclinePostProcessing(Record record, String previousApprovalStatus) {
         // Check if there's a random ID from a previous approval to uncache
-        String currentStatus = record.getUserInfo().getApprovalStatus();
-        String randomId = extractRandomIdFromCurrentStatus(currentStatus);
+        String statusForCleanup = previousApprovalStatus != null
+                ? previousApprovalStatus
+                : record.getUserInfo().getApprovalStatus();
+        String randomId = extractRandomIdFromCurrentStatus(statusForCleanup);
 
         if (randomId != null) {
             try {
-                LOGGER.info("RPA decline post-processing started reqId={} recordId={} stage=uncache",
-                        RPALogContext.requestId(), record.getId());
+                LOGGER.info("RPA decline post-processing started reqId={} recordId={} previousStatus={} stage=uncache",
+                        RPALogContext.requestId(), record.getId(),
+                        RPALogContext.summarizeApprovalStatus(statusForCleanup));
                 this.rpaDatasetCacher.uncache(randomId);
             } catch (Exception e) {
                 // Log but don't fail - the decline should still succeed

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/JKSKeyRetriever.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Key;
 import java.security.KeyStore;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Java Keystore implementation of the KeyRetriever interface.
@@ -16,6 +17,7 @@ import java.security.KeyStore;
 public class JKSKeyRetriever implements KeyRetriever {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(JKSKeyRetriever.class);
+    private static final AtomicBoolean KEYSTORE_LOGGED = new AtomicBoolean(false);
 
     /**
      * Loads the private key from the Java Keystore given the RPA configuration.
@@ -23,7 +25,10 @@ public class JKSKeyRetriever implements KeyRetriever {
     @Override
     public Key getKey(RPAConfiguration rpaConfiguration)  {
         try {
-            LOGGER.info("Using Java Keystore located at " + rpaConfiguration.getJksConfig().getKeyStorePath());
+            if (KEYSTORE_LOGGED.compareAndSet(false, true)) {
+                LOGGER.debug("RPA signing keystore initialized path={}",
+                        rpaConfiguration.getJksConfig().getKeyStorePath());
+            }
             KeyStore keystore = KeyStore.getInstance(rpaConfiguration.getJksConfig().getKeyStoreType());
             keystore.load(Files.newInputStream(
                             Paths.get(rpaConfiguration.getJksConfig().getKeyStorePath())),

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/JWTHelper.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/JWTHelper.java
@@ -120,7 +120,8 @@ public class JWTHelper {
                     "The URI may contain invalid characters or is not properly formatted.");
         }
 
-        LOGGER.debug("SEND_TOKEN_REQUEST_URL=" + url);
+        LOGGER.debug("RPA auth token request started reqId={} endpoint={}",
+                RPALogContext.requestId(), RPALogContext.safeUrl(url));
 
         HttpURLConnection connection = null;
         try {
@@ -139,20 +140,25 @@ public class JWTHelper {
                     while ((line = in.readLine()) != null) {
                         response.append(line);
                     }
-                    LOGGER.debug("SEND_TOKEN_REQUEST_RESPONSE=" + response);
-                    // Unmarshall response
                     ObjectMapper mapper = new ObjectMapper();
-                    return mapper.readValue(response.toString(), JWTToken.class);
+                    JWTToken token = mapper.readValue(response.toString(), JWTToken.class);
+                    LOGGER.debug("RPA auth token request succeeded reqId={} endpoint={}",
+                            RPALogContext.requestId(), RPALogContext.safeUrl(url));
+                    return token;
                 }
             } else {
-                LOGGER.debug("Access token request is invalid: " + connection.getResponseMessage());
+                LOGGER.warn("RPA auth token request failed reqId={} endpoint={} statusCode={} message={}",
+                        RPALogContext.requestId(), RPALogContext.safeUrl(url), responseCode,
+                        connection.getResponseMessage());
                 throw new InternalServerErrorException("Access token request is invalid: " + connection.getResponseMessage());
             }
         } catch (MalformedURLException e) {
-            LOGGER.debug("Invalid URL: " + e.getMessage());
+            LOGGER.error("RPA auth token request failed reqId={} reason=invalid-url message={}",
+                    RPALogContext.requestId(), e.getMessage());
             throw new InternalServerErrorException("Invalid URL: " + e.getMessage());
         } catch (IOException e) {
-            LOGGER.debug("Error sending POST request: " + e.getMessage());
+            LOGGER.error("RPA auth token request failed reqId={} endpoint={} message={}",
+                    RPALogContext.requestId(), RPALogContext.safeUrl(url), e.getMessage());
             throw new InternalServerErrorException("error sending POST request: " + e.getMessage());
         } finally {
             if (connection != null) {

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RPALogContext.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RPALogContext.java
@@ -1,0 +1,169 @@
+package gov.nist.oar.distrib.service.rpa;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.MDC;
+
+import gov.nist.oar.distrib.service.rpa.model.Record;
+
+/**
+ * Helper methods for keeping RPA workflow logging concise and correlated.
+ */
+public final class RPALogContext {
+
+    public static final String REQ_ID = "rpaReqId";
+    public static final String DATASET_ID = "rpaDatasetId";
+    public static final String RECORD_ID = "rpaRecordId";
+    public static final String CASE_NUM = "rpaCaseNum";
+    public static final String ACTOR = "rpaActor";
+
+    private RPALogContext() {
+    }
+
+    public static String begin(String datasetId, String recordId) {
+        String reqId = MDC.get(REQ_ID);
+        if (isBlank(reqId)) {
+            reqId = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+            MDC.put(REQ_ID, reqId);
+        }
+        putIfPresent(DATASET_ID, datasetId);
+        putIfPresent(RECORD_ID, recordId);
+        return reqId;
+    }
+
+    public static void setDatasetId(String datasetId) {
+        putIfPresent(DATASET_ID, datasetId);
+    }
+
+    public static void setRecordId(String recordId) {
+        putIfPresent(RECORD_ID, recordId);
+    }
+
+    public static void setCaseNum(String caseNum) {
+        putIfPresent(CASE_NUM, caseNum);
+    }
+
+    public static void setActor(String actor) {
+        putIfPresent(ACTOR, actor);
+    }
+
+    public static void updateFromRecord(Record record) {
+        if (record == null) {
+            return;
+        }
+        setRecordId(record.getId());
+        setCaseNum(record.getCaseNum());
+        if (record.getUserInfo() != null) {
+            setDatasetId(record.getUserInfo().getSubject());
+        }
+    }
+
+    public static String requestId() {
+        String reqId = MDC.get(REQ_ID);
+        return isBlank(reqId) ? begin(null, null) : reqId;
+    }
+
+    public static Map<String, String> capture() {
+        Map<String, String> context = MDC.getCopyOfContextMap();
+        if (context == null || context.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return new LinkedHashMap<>(context);
+    }
+
+    public static void restore(Map<String, String> context) {
+        if (context == null || context.isEmpty()) {
+            MDC.clear();
+        } else {
+            MDC.setContextMap(context);
+        }
+    }
+
+    public static String safeUrl(String url) {
+        if (isBlank(url)) {
+            return "unknown";
+        }
+        try {
+            URI uri = new URI(url);
+            StringBuilder out = new StringBuilder();
+            if (uri.getScheme() != null) {
+                out.append(uri.getScheme()).append("://");
+            }
+            if (uri.getHost() != null) {
+                out.append(uri.getHost());
+            }
+            if (uri.getPort() > 0) {
+                out.append(":").append(uri.getPort());
+            }
+            if (uri.getPath() != null) {
+                out.append(uri.getPath());
+            }
+            if (out.length() == 0) {
+                return url;
+            }
+            return out.toString();
+        } catch (URISyntaxException ex) {
+            return url;
+        }
+    }
+
+    public static String maskEmail(String email) {
+        if (isBlank(email)) {
+            return "unknown";
+        }
+        int at = email.indexOf('@');
+        if (at <= 1 || at == email.length() - 1) {
+            return email;
+        }
+        return email.substring(0, 1) + "***" + email.substring(at);
+    }
+
+    public static String emailDomain(String email) {
+        if (isBlank(email)) {
+            return "unknown";
+        }
+        int at = email.indexOf('@');
+        if (at < 0 || at == email.length() - 1) {
+            return "unknown";
+        }
+        return email.substring(at + 1);
+    }
+
+    public static int recipientCount(String recipients) {
+        if (isBlank(recipients)) {
+            return 0;
+        }
+        String[] parts = recipients.split(";");
+        int count = 0;
+        for (String part : parts) {
+            if (!isBlank(part)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static String summarizeApprovalStatus(String approvalStatus) {
+        if (isBlank(approvalStatus)) {
+            return "unknown";
+        }
+        int idx = approvalStatus.indexOf('_');
+        return idx >= 0 ? approvalStatus.substring(0, idx) : approvalStatus;
+    }
+
+    private static void putIfPresent(String key, String value) {
+        if (isBlank(value)) {
+            return;
+        }
+        MDC.put(key, value);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandler.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RPARequestHandler.java
@@ -24,7 +24,7 @@ public interface RPARequestHandler {
          *
          * For approvals, this sets an interim "ApprovalPending" status and returns immediately.
          * The actual caching and final status update happen asynchronously via
-         * {@link #handleAfterRecordUpdate(Record, String, String)}.
+         * {@link #handleAfterRecordUpdate(Record, String, String, String)}.
          *
          * @param recordId the ID of the record to update
          * @param status   the new status for the record
@@ -50,7 +50,26 @@ public interface RPARequestHandler {
          * @param datasetId the ID of the dataset associated with the record
          * @throws RequestProcessingException if an error occurs during post-processing
          */
-        void handleAfterRecordUpdate(Record record, String status, String datasetId)
+        default void handleAfterRecordUpdate(Record record, String status, String datasetId)
+                        throws RequestProcessingException {
+                String previousApprovalStatus = record != null && record.getUserInfo() != null
+                                ? record.getUserInfo().getApprovalStatus()
+                                : null;
+                handleAfterRecordUpdate(record, status, datasetId, previousApprovalStatus);
+        }
+
+        /**
+         * Handles post-processing with the record's status before the synchronous
+         * update. This is needed for decline cleanup because the random cart ID exists
+         * only in the previous approved status string.
+         *
+         * @param record                 the record that was updated
+         * @param status                 the approval status ("approved" or "declined")
+         * @param datasetId              the ID of the dataset associated with the record
+         * @param previousApprovalStatus the approval status before the synchronous patch
+         * @throws RequestProcessingException if an error occurs during post-processing
+         */
+        void handleAfterRecordUpdate(Record record, String status, String datasetId, String previousApprovalStatus)
                         throws RequestProcessingException;
 
         /**

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RecordResponseHandlerImpl.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RecordResponseHandlerImpl.java
@@ -158,7 +158,12 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onRecordUpdateDeclined(Record record) throws InvalidRequestException, RequestProcessingException {
-        LOGGER.debug("User was declined by SME");
+        LOGGER.debug("User was declined by SME. Sending decline notification...");
+        if (this.emailSender.sendDeclinedEmailToEndUser(record)) {
+            LOGGER.debug("Decline notification email sent successfully (RecordID=" + record.getId() + ")");
+        } else {
+            throw new RequestProcessingException("Failed to send decline notification email to end user");
+        }
     }
 
     /**

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RecordResponseHandlerImpl.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RecordResponseHandlerImpl.java
@@ -63,17 +63,22 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onRecordCreationSuccess(Record record) throws InvalidRequestException, RequestProcessingException {
-        LOGGER.debug("Record with ID=" + record.getId() + " created successfully! Now sending emails...");
+        RPALogContext.updateFromRecord(record);
+        LOGGER.info("RPA post-create notifications started reqId={} recordId={} caseNum={} approvalStatus={}",
+                RPALogContext.requestId(), record.getId(), record.getCaseNum(),
+                RPALogContext.summarizeApprovalStatus(record.getUserInfo().getApprovalStatus()));
         // If sending email was successful
         if (this.emailSender.sendConfirmationEmailToEndUser(record)) {
-            LOGGER.debug("Confirmation email sent to end user successfully! (RecordID=" + record.getId() + ")");
+            LOGGER.debug("RPA confirmation email completed reqId={} recordId={}",
+                    RPALogContext.requestId(), record.getId());
         } else {
             throw new RequestProcessingException("Unable to send confirmation email to end user");
         }
 
         // If sending email was successful
         if (this.emailSender.sendApprovalEmailToSME(record)) {
-            LOGGER.debug("Request approval email sent to SME successfully! (RecordID=" + record.getId() + ")");
+            LOGGER.info("RPA SME approval notification completed reqId={} recordId={}",
+                    RPALogContext.requestId(), record.getId());
         } else {
             throw new RequestProcessingException("Unable to send request approval email to SME");
         }
@@ -88,7 +93,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onRecordCreationFailure(int statusCode) throws RequestProcessingException {
-        LOGGER.debug("Failed to create record, status_code=" + statusCode);
+        LOGGER.error("RPA record creation failed reqId={} statusCode={}", RPALogContext.requestId(), statusCode);
         throw new RequestProcessingException("Failed to create record, status_code=" + statusCode);
     }
     
@@ -100,7 +105,9 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onPreApprovedRecordCreationSuccess(Record record, String randomId) throws RequestProcessingException {
-        LOGGER.debug("Handling success for pre-approved record with ID: " + record.getId());
+        RPALogContext.updateFromRecord(record);
+        LOGGER.info("RPA pre-approved request completed reqId={} recordId={} caseNum={}",
+                RPALogContext.requestId(), record.getId(), record.getCaseNum());
 
         // Generate the download URL
         String downloadUrl;
@@ -115,7 +122,8 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
 
         // Send combined email for pre-approved record
         if (this.emailSender.sendPreApprovedEmailToEndUser(record, downloadUrl)) {
-            LOGGER.debug("Pre-approved email sent successfully (RecordID=" + record.getId() + ")");
+            LOGGER.info("RPA pre-approved email completed reqId={} recordId={}",
+                    RPALogContext.requestId(), record.getId());
         } else {
             throw new RequestProcessingException("Failed to send pre-approved email");
         }
@@ -133,8 +141,10 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onRecordUpdateApproved(Record record, String randomId) throws InvalidRequestException, RequestProcessingException {
-
-        LOGGER.info("Dataset was cached successfully. Sending email to user...");
+        RPALogContext.updateFromRecord(record);
+        LOGGER.info("RPA approval notification started reqId={} recordId={} caseNum={} finalStatus={}",
+                RPALogContext.requestId(), record.getId(), record.getCaseNum(),
+                RPALogContext.summarizeApprovalStatus(record.getUserInfo().getApprovalStatus()));
 
         // Build Download URL
         String downloadUrl;
@@ -158,9 +168,12 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onRecordUpdateDeclined(Record record) throws InvalidRequestException, RequestProcessingException {
-        LOGGER.debug("User was declined by SME. Sending decline notification...");
+        RPALogContext.updateFromRecord(record);
+        LOGGER.info("RPA decline notification started reqId={} recordId={} caseNum={}",
+                RPALogContext.requestId(), record.getId(), record.getCaseNum());
         if (this.emailSender.sendDeclinedEmailToEndUser(record)) {
-            LOGGER.debug("Decline notification email sent successfully (RecordID=" + record.getId() + ")");
+            LOGGER.info("RPA decline notification completed reqId={} recordId={}",
+                    RPALogContext.requestId(), record.getId());
         } else {
             throw new RequestProcessingException("Failed to send decline notification email to end user");
         }
@@ -176,12 +189,14 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
      */
     @Override
     public void onFailure(Record record) throws RequestProcessingException, InvalidRequestException {
-        LOGGER.warn("A processing failure occurred for Record ID=" + record.getId() +
-                "; notifying the user that their request could not be completed.");
+        RPALogContext.updateFromRecord(record);
+        LOGGER.warn("RPA processing failure notification started reqId={} recordId={} caseNum={}",
+                RPALogContext.requestId(), record.getId(), record.getCaseNum());
 
         boolean sent = this.emailSender.sendFailureNotificationEmailToEndUser(record);
         if (sent) {
-            LOGGER.debug("Failure notification email sent successfully to end user (RecordID=" + record.getId() + ")");
+            LOGGER.info("RPA processing failure notification completed reqId={} recordId={}",
+                    RPALogContext.requestId(), record.getId());
         } else {
             throw new RequestProcessingException("Failed to send failure notification email to end user");
         }
@@ -245,8 +260,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
         private boolean sendApprovalEmailToSME(Record record) throws InvalidRequestException,
                 RequestProcessingException {
             EmailInfo emailInfo = this.emailInfoProvider.getSMEApprovalEmailInfo(record);
-            LOGGER.debug("EMAIL_INFO=" + emailInfo);
-            return this.send(emailInfo) == HttpURLConnection.HTTP_OK;
+            return this.send("sme-approval", emailInfo) == HttpURLConnection.HTTP_OK;
         }
 
         /**
@@ -259,8 +273,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
         private boolean sendConfirmationEmailToEndUser(Record record) throws InvalidRequestException,
                 RequestProcessingException {
             EmailInfo emailInfo = this.emailInfoProvider.getEndUserConfirmationEmailInfo(record);
-            LOGGER.debug("EMAIL_INFO=" + emailInfo);
-            return this.send(emailInfo) == HttpURLConnection.HTTP_OK;
+            return this.send("request-confirmation", emailInfo) == HttpURLConnection.HTTP_OK;
         }
 
         /**
@@ -273,8 +286,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
         private boolean sendDownloadEmailToEndUser(Record record, String downloadUrl) throws InvalidRequestException,
                 RequestProcessingException {
             EmailInfo emailInfo = this.emailInfoProvider.getEndUserApprovedEmailInfo(record, downloadUrl);
-            LOGGER.debug("EMAIL_INFO=" + emailInfo);
-            return this.send(emailInfo) == HttpURLConnection.HTTP_OK;
+            return this.send("approved-download", emailInfo) == HttpURLConnection.HTTP_OK;
         }
 
         /**
@@ -286,8 +298,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
          */
         private boolean sendPreApprovedEmailToEndUser(Record record, String downloadUrl) throws InvalidRequestException, RequestProcessingException {
             EmailInfo emailInfo = EmailHelper.getEndUserPreApprovedEmailInfo(record, this.rpaConfiguration, downloadUrl);
-            LOGGER.debug("EMAIL_INFO=" + emailInfo);
-            return this.send(emailInfo) == HttpURLConnection.HTTP_OK;
+            return this.send("pre-approved-download", emailInfo) == HttpURLConnection.HTTP_OK;
         }
 
 
@@ -300,8 +311,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
         private boolean sendDeclinedEmailToEndUser(Record record) throws InvalidRequestException,
                 RequestProcessingException {
             EmailInfo emailInfo = this.emailInfoProvider.getEndUserDeclinedEmailInfo(record);
-            LOGGER.debug("EMAIL_INFO=" + emailInfo);
-            return this.send(emailInfo) == HttpURLConnection.HTTP_OK;
+            return this.send("declined-notification", emailInfo) == HttpURLConnection.HTTP_OK;
         }
 
         /**
@@ -314,8 +324,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
         private boolean sendFailureNotificationEmailToEndUser(Record record)
                 throws InvalidRequestException, RequestProcessingException {
             EmailInfo emailInfo = this.emailInfoProvider.getEndUserFailureNotificationEmailInfo(record);
-            LOGGER.debug("EMAIL_INFO (processing failure)=" + emailInfo);
-            return this.send(emailInfo) == HttpURLConnection.HTTP_OK;
+            return this.send("processing-failure", emailInfo) == HttpURLConnection.HTTP_OK;
         }
 
         /**
@@ -326,7 +335,7 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
          * @throws InvalidRequestException    if the email request is invalid
          * @throws RequestProcessingException if there is an error processing the email request
          */
-        private int send(EmailInfo emailInfo) throws InvalidRequestException, RequestProcessingException {
+        private int send(String emailKind, EmailInfo emailInfo) throws InvalidRequestException, RequestProcessingException {
             int responseCode;
             EmailInfoWrapper emailInfoWrapper = null;
             String sendEmailUri = this.rpaConfiguration.getSalesforceEndpoints().get(SEND_EMAIL_ENDPOINT_KEY);
@@ -342,13 +351,16 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
             } catch (URISyntaxException e) {
                 throw new RequestProcessingException("Error building URI: " + e.getMessage());
             }
-            LOGGER.debug("SEND_EMAIL_URL=" + url);
+            LOGGER.debug("RPA email request prepared reqId={} kind={} endpoint={} recordId={} recipientCount={}",
+                    RPALogContext.requestId(), emailKind, RPALogContext.safeUrl(url), emailInfo.getRecordId(),
+                    RPALogContext.recipientCount(emailInfo.getRecipient()));
             // Create payload
             String postPayload;
             try {
                 postPayload = new ObjectMapper().writeValueAsString(emailInfo);
             } catch (JsonProcessingException e) {
-                LOGGER.debug("Error while serializing user info: " + e.getMessage());
+                LOGGER.error("RPA email serialization failed reqId={} kind={} recordId={}: {}",
+                        RPALogContext.requestId(), emailKind, emailInfo.getRecordId(), e.getMessage());
                 throw new RequestProcessingException("Error while serializing user info: " + e.getMessage());
             }
 
@@ -367,7 +379,6 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
                 os.write(payloadBytes);
                 os.flush();
                 os.close();
-                LOGGER.debug("SEND_EMAIL_PAYLOAD=" + postPayload);
                 responseCode = connection.getResponseCode();
                 if (responseCode == HttpURLConnection.HTTP_OK) { // If created
                     try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
@@ -377,26 +388,34 @@ public class RecordResponseHandlerImpl implements RecordResponseHandler {
                         while ((line = in.readLine()) != null) {
                             response.append(line);
                         }
-                        LOGGER.debug("SEND_EMAIL_RESPONSE=" + response);
                         // Handle the response
                         emailInfoWrapper = new ObjectMapper().readValue(response.toString(), EmailInfoWrapper.class);
+                        LOGGER.info("RPA email sent reqId={} kind={} recordId={} recipientCount={} statusCode={}",
+                                RPALogContext.requestId(), emailKind, emailInfo.getRecordId(),
+                                RPALogContext.recipientCount(emailInfo.getRecipient()), responseCode);
                     }
                 } else if (responseCode == HttpURLConnection.HTTP_BAD_REQUEST) { // If bad request
-                    LOGGER.error("Invalid request: " + connection.getResponseMessage());
+                    LOGGER.warn("RPA email rejected reqId={} kind={} recordId={} statusCode={} message={}",
+                            RPALogContext.requestId(), emailKind, emailInfo.getRecordId(), responseCode,
+                            connection.getResponseMessage());
                     throw new InvalidRequestException("Invalid request: " + connection.getResponseMessage());
                 } else {
                     // Handle any other error response
-                    LOGGER.error("Error response from Salesforce service: " + connection.getResponseMessage());
+                    LOGGER.error("RPA email failed reqId={} kind={} recordId={} statusCode={} message={}",
+                            RPALogContext.requestId(), emailKind, emailInfo.getRecordId(), responseCode,
+                            connection.getResponseMessage());
                     throw new RequestProcessingException("Error response from Salesforce service: " + connection.getResponseMessage());
                 }
 
             } catch (MalformedURLException e) {
                 // Handle the URL Malformed error
-                LOGGER.error("Invalid URL: " + e.getMessage());
+                LOGGER.error("RPA email failed reqId={} kind={} recordId={} reason=invalid-url message={}",
+                        RPALogContext.requestId(), emailKind, emailInfo.getRecordId(), e.getMessage());
                 throw new RequestProcessingException("Invalid URL: " + e.getMessage());
             } catch (IOException e) {
                 // Handle the I/O error
-                LOGGER.error("Error sending GET request: " + e.getMessage());
+                LOGGER.error("RPA email failed reqId={} kind={} recordId={} message={}",
+                        RPALogContext.requestId(), emailKind, emailInfo.getRecordId(), e.getMessage());
                 throw new RequestProcessingException("I/O error: " + e.getMessage());
             } finally {
                 // Close the connection

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RecordUpdateResult.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RecordUpdateResult.java
@@ -1,0 +1,33 @@
+package gov.nist.oar.distrib.service.rpa;
+
+import gov.nist.oar.distrib.service.rpa.model.Record;
+import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
+
+/**
+ * Encapsulates the result of a record update operation.
+ * Contains the data needed for async post-processing after the synchronous
+ * update completes.
+ */
+public class RecordUpdateResult {
+    private final RecordStatus recordStatus;
+    private final Record record;
+    private final String datasetId;
+
+    public RecordUpdateResult(RecordStatus recordStatus, Record record, String datasetId) {
+        this.recordStatus = recordStatus;
+        this.record = record;
+        this.datasetId = datasetId;
+    }
+
+    public RecordStatus getRecordStatus() {
+        return recordStatus;
+    }
+
+    public Record getRecord() {
+        return record;
+    }
+
+    public String getDatasetId() {
+        return datasetId;
+    }
+}

--- a/src/main/java/gov/nist/oar/distrib/service/rpa/RecordUpdateResult.java
+++ b/src/main/java/gov/nist/oar/distrib/service/rpa/RecordUpdateResult.java
@@ -12,11 +12,18 @@ public class RecordUpdateResult {
     private final RecordStatus recordStatus;
     private final Record record;
     private final String datasetId;
+    private final String previousApprovalStatus;
 
     public RecordUpdateResult(RecordStatus recordStatus, Record record, String datasetId) {
+        this(recordStatus, record, datasetId, null);
+    }
+
+    public RecordUpdateResult(RecordStatus recordStatus, Record record, String datasetId,
+            String previousApprovalStatus) {
         this.recordStatus = recordStatus;
         this.record = record;
         this.datasetId = datasetId;
+        this.previousApprovalStatus = previousApprovalStatus;
     }
 
     public RecordStatus getRecordStatus() {
@@ -29,5 +36,9 @@ public class RecordUpdateResult {
 
     public String getDatasetId() {
         return datasetId;
+    }
+
+    public String getPreviousApprovalStatus() {
+        return previousApprovalStatus;
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/JwtTokenValidator.java
+++ b/src/main/java/gov/nist/oar/distrib/web/JwtTokenValidator.java
@@ -82,8 +82,6 @@ public class JwtTokenValidator {
             tokenDetails.put("expiry", getClaimAsString(claims.get("exp"), "exp", false));
             tokenDetails.put("user_id", getClaimAsString(claims.getSubject(), "user_id", true));
 
-            LOGGER.debug("Token successfully validated and details extracted.");
-
             return tokenDetails;
 
         } catch (MissingRequiredClaimException e) {
@@ -93,7 +91,7 @@ public class JwtTokenValidator {
             throw e;
         } catch (JwtException ex) {
             // If the token is expired or signature does not match, it will throw an Exception
-            LOGGER.debug("Token validation failed due to JwtException: ", ex);
+            LOGGER.debug("RPA JWT validation failed: {}", ex.getMessage());
             throw ex;
         }
     }

--- a/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.Async;
 
 import gov.nist.oar.distrib.service.rpa.RPARequestHandler;
 import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
+import gov.nist.oar.distrib.service.rpa.model.Record;
 import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
 import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
 
@@ -38,6 +39,24 @@ public class RPAAsyncExecutor {
         } catch (RequestProcessingException e) {
             LOGGER.error("Async post-processing failed for record ID {}: {}", wrapper.getRecord().getId(),
                     e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Handle the post-processing of a record update (approval/decline) asynchronously.
+     * This method does not throw any exceptions; rather, it logs any errors and continues.
+     *
+     * @param record    The record that was updated.
+     * @param status    The approval status ("approved" or "declined").
+     * @param datasetId The ID of the dataset associated with the record.
+     */
+    @Async
+    public void handleAfterRecordUpdateAsync(Record record, String status, String datasetId) {
+        try {
+            handler.handleAfterRecordUpdate(record, status, datasetId);
+        } catch (RequestProcessingException e) {
+            LOGGER.error("Async post-processing failed for record update (record ID {}): {}",
+                    record.getId(), e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
@@ -63,10 +63,34 @@ public class RPAAsyncExecutor {
     @Async
     public void handleAfterRecordUpdateAsync(Record record, String status, String datasetId,
             Map<String, String> logContext) {
+        String previousApprovalStatus = record != null && record.getUserInfo() != null
+                ? record.getUserInfo().getApprovalStatus()
+                : null;
+        doHandleAfterRecordUpdate(record, status, datasetId, previousApprovalStatus, logContext);
+    }
+
+    /**
+     * Handle the post-processing of a record update with the approval status that
+     * existed before the synchronous patch.
+     *
+     * @param record                 The record that was updated.
+     * @param status                 The approval status ("approved" or "declined").
+     * @param datasetId              The ID of the dataset associated with the record.
+     * @param previousApprovalStatus The approval status before the synchronous patch.
+     * @param logContext             The logging context to restore in the async thread.
+     */
+    @Async
+    public void handleAfterRecordUpdateAsync(Record record, String status, String datasetId,
+            String previousApprovalStatus, Map<String, String> logContext) {
+        doHandleAfterRecordUpdate(record, status, datasetId, previousApprovalStatus, logContext);
+    }
+
+    private void doHandleAfterRecordUpdate(Record record, String status, String datasetId,
+            String previousApprovalStatus, Map<String, String> logContext) {
         Map<String, String> previousContext = RPALogContext.capture();
         RPALogContext.restore(logContext);
         try {
-            handler.handleAfterRecordUpdate(record, status, datasetId);
+            handler.handleAfterRecordUpdate(record, status, datasetId, previousApprovalStatus);
         } catch (RequestProcessingException e) {
             String recordId = record != null ? record.getId() : "unknown";
             LOGGER.error("RPA async update post-processing failed reqId={} recordId={} action={}: {}",

--- a/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
@@ -37,7 +37,8 @@ public class RPAAsyncExecutor {
         try {
             handler.handleAfterRecordCreation(wrapper, input, code);
         } catch (RequestProcessingException e) {
-            LOGGER.error("Async post-processing failed for record ID {}: {}", wrapper.getRecord().getId(),
+            String recordId = wrapper != null && wrapper.getRecord() != null ? wrapper.getRecord().getId() : "unknown";
+            LOGGER.error("Async post-processing failed for record ID {}: {}", recordId,
                     e.getMessage(), e);
         }
     }

--- a/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAAsyncExecutor.java
@@ -1,9 +1,12 @@
 package gov.nist.oar.distrib.web;
 
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 
+import gov.nist.oar.distrib.service.rpa.RPALogContext;
 import gov.nist.oar.distrib.service.rpa.RPARequestHandler;
 import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
 import gov.nist.oar.distrib.service.rpa.model.Record;
@@ -27,19 +30,25 @@ public class RPAAsyncExecutor {
      * method does not throw any exceptions; rather, it logs any errors and
      * continues.
      * 
-     * @param wrapper The RecordWrapper containing the record and its
+    * @param wrapper The RecordWrapper containing the record and its
      *                details.
      * @param input   The UserInfoWrapper containing the original input data
      *                used to create the record.
      */
     @Async
-    public void handleAfterRecordCreationAsync(RecordWrapper wrapper, UserInfoWrapper input, int code) {
+    public void handleAfterRecordCreationAsync(RecordWrapper wrapper, UserInfoWrapper input, int code,
+            Map<String, String> logContext) {
+        Map<String, String> previousContext = RPALogContext.capture();
+        RPALogContext.restore(logContext);
         try {
             handler.handleAfterRecordCreation(wrapper, input, code);
         } catch (RequestProcessingException e) {
             String recordId = wrapper != null && wrapper.getRecord() != null ? wrapper.getRecord().getId() : "unknown";
-            LOGGER.error("Async post-processing failed for record ID {}: {}", recordId,
+            LOGGER.error("RPA async create post-processing failed reqId={} recordId={}: {}",
+                    RPALogContext.requestId(), recordId,
                     e.getMessage(), e);
+        } finally {
+            RPALogContext.restore(previousContext);
         }
     }
 
@@ -52,12 +61,18 @@ public class RPAAsyncExecutor {
      * @param datasetId The ID of the dataset associated with the record.
      */
     @Async
-    public void handleAfterRecordUpdateAsync(Record record, String status, String datasetId) {
+    public void handleAfterRecordUpdateAsync(Record record, String status, String datasetId,
+            Map<String, String> logContext) {
+        Map<String, String> previousContext = RPALogContext.capture();
+        RPALogContext.restore(logContext);
         try {
             handler.handleAfterRecordUpdate(record, status, datasetId);
         } catch (RequestProcessingException e) {
-            LOGGER.error("Async post-processing failed for record update (record ID {}): {}",
-                    record.getId(), e.getMessage(), e);
+            String recordId = record != null ? record.getId() : "unknown";
+            LOGGER.error("RPA async update post-processing failed reqId={} recordId={} action={}: {}",
+                    RPALogContext.requestId(), recordId, status, e.getMessage(), e);
+        } finally {
+            RPALogContext.restore(previousContext);
         }
     }
 }

--- a/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPAConfiguration.java
@@ -61,7 +61,7 @@ public class RPAConfiguration {
     private Map<String, BlacklistConfig> blacklists = new HashMap<>();
 
     @JsonProperty("expiresAfterMillis")
-    long expiresAfterMillis = 0L;
+    long expiresAfterMillis = 1209600000L;
 
     @JsonProperty("supportEmail")
     private String supportEmail;

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -1,6 +1,7 @@
 package gov.nist.oar.distrib.web;
 
 import gov.nist.oar.distrib.service.RPACachingService;
+import gov.nist.oar.distrib.service.rpa.RPALogContext;
 import gov.nist.oar.distrib.service.rpa.RPARequestHandler;
 import gov.nist.oar.distrib.service.rpa.RecordCreationResult;
 import gov.nist.oar.distrib.service.rpa.RecordUpdateResult;
@@ -236,35 +237,56 @@ public class RPARequestHandlerController {
             @RequestHeader(value = HttpHeaders.AUTHORIZATION) String authorizationHeader)
             throws RecordNotFoundException, RequestProcessingException, UnauthorizedException {
 
-        _checkForService();
-        LOGGER.debug("Attempting to retrieve record with ID {}", id);
+        Map<String, String> previousContext = RPALogContext.capture();
+        try {
+            _checkForService();
+            RPALogContext.begin(null, id);
+            LOGGER.debug("RPA record fetch requested reqId={} recordId={}", RPALogContext.requestId(), id);
 
-        // Extracting the token from the header
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring("Bearer ".length());
+            // Extracting the token from the header
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                String token = authorizationHeader.substring("Bearer ".length());
 
-            // Validate token using JwtTokenValidator
-            boolean isValid = false;
-            try {
-                isValid = jwtTokenValidator.validate(token) != null;
-                LOGGER.debug("Token validation successful for record with ID: {}", id);
-            } catch (Exception e) {
-                LOGGER.error("Error during token validation for record with ID: {}. Error Message: {}", id,
-                        e.getMessage());
-                throw new RequestProcessingException(e.getMessage());
-            }
+                // Validate token using JwtTokenValidator
+                Map<String, String> tokenDetails = null;
+                boolean isValid = false;
+                try {
+                    tokenDetails = jwtTokenValidator.validate(token);
+                    isValid = tokenDetails != null;
+                    if (tokenDetails != null) {
+                        RPALogContext.setActor(RPALogContext.maskEmail(tokenDetails.get("userEmail")));
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("RPA record fetch failed during token validation reqId={} recordId={}: {}",
+                            RPALogContext.requestId(), id, e.getMessage());
+                    throw new RequestProcessingException(e.getMessage());
+                }
 
-            if (isValid) {
-                RecordWrapper recordWrapper = service.getRecord(id);
-                LOGGER.debug("Successfully retrieved record with ID: {}", id);
-                return new ResponseEntity<RecordWrapper>(recordWrapper, HttpStatus.OK);
+                if (isValid) {
+                    RecordWrapper recordWrapper = service.getRecord(id);
+                    if (recordWrapper != null && recordWrapper.getRecord() != null) {
+                        RPALogContext.updateFromRecord(recordWrapper.getRecord());
+                        LOGGER.debug(
+                                "RPA record fetch succeeded reqId={} recordId={} caseNum={} approvalStatus={}",
+                                RPALogContext.requestId(),
+                                recordWrapper.getRecord().getId(),
+                                recordWrapper.getRecord().getCaseNum(),
+                                RPALogContext
+                                        .summarizeApprovalStatus(recordWrapper.getRecord().getUserInfo().getApprovalStatus()));
+                    }
+                    return new ResponseEntity<RecordWrapper>(recordWrapper, HttpStatus.OK);
+                } else {
+                    LOGGER.warn("RPA record fetch denied reqId={} recordId={} reason=invalid-token",
+                            RPALogContext.requestId(), id);
+                    throw new UnauthorizedException("invalid token");
+                }
             } else {
-                LOGGER.warn("Invalid token provided for record with ID: {}", id);
-                throw new UnauthorizedException("invalid token");
+                LOGGER.warn("RPA record fetch denied reqId={} recordId={} reason=invalid-authorization-header",
+                        RPALogContext.requestId(), id);
+                throw new UnauthorizedException("invalid authorization header");
             }
-        } else {
-            LOGGER.warn("Invalid authorization header for record with ID: {}", id);
-            throw new UnauthorizedException("invalid authorization header");
+        } finally {
+            RPALogContext.restore(previousContext);
         }
     }
 
@@ -306,38 +328,63 @@ public class RPARequestHandlerController {
     public ResponseEntity<RecordWrapper> createRecord(@RequestBody UserInfoWrapper userInfoWrapper,
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader)
             throws InvalidRequestException, RecaptchaVerificationFailedException, RequestProcessingException {
-        _checkForService();
-        LOGGER.debug("Attempting to create a new record...");
+        Map<String, String> previousContext = RPALogContext.capture();
+        try {
+            _checkForService();
+            String datasetId = userInfoWrapper != null && userInfoWrapper.getUserInfo() != null
+                    ? userInfoWrapper.getUserInfo().getSubject()
+                    : null;
+            String email = userInfoWrapper != null && userInfoWrapper.getUserInfo() != null
+                    ? userInfoWrapper.getUserInfo().getEmail()
+                    : null;
+            RPALogContext.begin(datasetId, null);
 
-        // Check if reCAPTCHA verification should be skipped
-        boolean shouldVerifyRecaptcha = recaptchaHelper.shouldVerifyRecaptcha(authorizationHeader);
+            // Check if reCAPTCHA verification should be skipped
+            boolean shouldVerifyRecaptcha = recaptchaHelper.shouldVerifyRecaptcha(authorizationHeader);
+            LOGGER.info("RPA create request received reqId={} dataset={} emailDomain={} recaptchaRequired={}",
+                    RPALogContext.requestId(), datasetId, RPALogContext.emailDomain(email), shouldVerifyRecaptcha);
 
-        RecaptchaResponse recaptchaResponse;
-        if (shouldVerifyRecaptcha) {
-            String recaptchaToken = userInfoWrapper.getRecaptcha();
-            try {
-                recaptchaResponse = recaptchaHelper.verifyRecaptcha(recaptchaToken);
-            } catch (RecaptchaServerException e) {
-                throw new RequestProcessingException(e.getMessage());
-            } catch (RecaptchaClientException e) {
-                throw new InvalidRequestException(e.getMessage());
+            RecaptchaResponse recaptchaResponse;
+            if (shouldVerifyRecaptcha) {
+                String recaptchaToken = userInfoWrapper.getRecaptcha();
+                try {
+                    recaptchaResponse = recaptchaHelper.verifyRecaptcha(recaptchaToken);
+                } catch (RecaptchaServerException e) {
+                    throw new RequestProcessingException(e.getMessage());
+                } catch (RecaptchaClientException e) {
+                    throw new InvalidRequestException(e.getMessage());
+                }
+
+                if (!recaptchaResponse.isSuccess()) {
+                    throw new RecaptchaVerificationFailedException("reCAPTCHA verification failed");
+                }
             }
 
-            if (!recaptchaResponse.isSuccess()) {
-                throw new RecaptchaVerificationFailedException("reCAPTCHA verification failed");
+            // Sanitize and validate the user input
+            requestSanitizer.sanitizeAndValidate(userInfoWrapper);
+            LOGGER.debug("RPA create request validated reqId={} dataset={}", RPALogContext.requestId(), datasetId);
+
+            RecordCreationResult result = service.createRecord(userInfoWrapper);
+            if (result != null && result.getRecordWrapper() != null && result.getRecordWrapper().getRecord() != null) {
+                RPALogContext.updateFromRecord(result.getRecordWrapper().getRecord());
+                LOGGER.info(
+                        "RPA record created reqId={} dataset={} recordId={} caseNum={} approvalStatus={} statusCode={}",
+                        RPALogContext.requestId(),
+                        datasetId,
+                        result.getRecordWrapper().getRecord().getId(),
+                        result.getRecordWrapper().getRecord().getCaseNum(),
+                        RPALogContext
+                                .summarizeApprovalStatus(result.getRecordWrapper().getRecord().getUserInfo().getApprovalStatus()),
+                        result.getStatusCode());
             }
+
+            asyncExecutor.handleAfterRecordCreationAsync(
+                    result.getRecordWrapper(), userInfoWrapper, result.getStatusCode(), RPALogContext.capture());
+
+            return ResponseEntity.ok(result.getRecordWrapper());
+        } finally {
+            RPALogContext.restore(previousContext);
         }
-
-        // Sanitize and validate the user input
-        LOGGER.debug("Sanitizing and validating user input...");
-        requestSanitizer.sanitizeAndValidate(userInfoWrapper);
-
-        RecordCreationResult result = service.createRecord(userInfoWrapper);
-
-        asyncExecutor.handleAfterRecordCreationAsync(result.getRecordWrapper(), userInfoWrapper, result.getStatusCode());
-
-        LOGGER.debug("Record successfully created. Returning response.");
-        return ResponseEntity.ok(result.getRecordWrapper());
     }
 
     /**
@@ -376,50 +423,62 @@ public class RPARequestHandlerController {
             @RequestHeader(value = HttpHeaders.AUTHORIZATION) String authorizationHeader)
             throws RecordNotFoundException, InvalidRequestException, RequestProcessingException, UnauthorizedException {
 
-        _checkForService();
-        LOGGER.debug("Attempting to update record with ID: {}", id);
+        Map<String, String> previousContext = RPALogContext.capture();
+        try {
+            _checkForService();
+            RPALogContext.begin(null, id);
 
-        // Extracting the token from the header
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String token = authorizationHeader.substring("Bearer ".length());
-            // Validate token using JwtTokenValidator
-            Map<String, String> tokenDetails = null;
-            try {
-                tokenDetails = jwtTokenValidator.validate(token);
-                LOGGER.debug("Token is validated");
-            } catch (MissingRequiredClaimException e) {
-                String missingClaimName = e.getMissingClaimName();
-                LOGGER.debug("Missing required claim detected: " + missingClaimName);
-                throw new InvalidRequestException("JWT token invalid");
-            } catch (JwtException e) {
-                LOGGER.debug("Token validation failed due to a JwtException: " + e.getMessage());
-                throw new UnauthorizedException("JWT token validation failed");
-            }
+            // Extracting the token from the header
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                String token = authorizationHeader.substring("Bearer ".length());
+                // Validate token using JwtTokenValidator
+                Map<String, String> tokenDetails = null;
+                try {
+                    tokenDetails = jwtTokenValidator.validate(token);
+                } catch (MissingRequiredClaimException e) {
+                    String missingClaimName = e.getMissingClaimName();
+                    LOGGER.warn("RPA record update rejected reqId={} recordId={} reason=missing-claim claim={}",
+                            RPALogContext.requestId(), id, missingClaimName);
+                    throw new InvalidRequestException("JWT token invalid");
+                } catch (JwtException e) {
+                    LOGGER.warn("RPA record update denied reqId={} recordId={} reason=jwt-validation-failed",
+                            RPALogContext.requestId(), id);
+                    throw new UnauthorizedException("JWT token validation failed");
+                }
 
-            if (tokenDetails != null) {
-                LOGGER.debug("Updating record with ID: {}", id);
-                String smeId = tokenDetails.get("userEmail");
-                RecordUpdateResult result = service.updateRecord(id, patch.getApprovalStatus(), smeId);
+                if (tokenDetails != null) {
+                    String smeId = tokenDetails.get("userEmail");
+                    String requestedStatus = patch != null ? patch.getApprovalStatus() : null;
+                    RPALogContext.setActor(RPALogContext.maskEmail(smeId));
+                    LOGGER.info("RPA record update requested reqId={} recordId={} action={} actor={}",
+                            RPALogContext.requestId(), id, requestedStatus, RPALogContext.maskEmail(smeId));
+                    RecordUpdateResult result = service.updateRecord(id, requestedStatus, smeId);
+                    RPALogContext.updateFromRecord(result.getRecord());
+                    RPALogContext.setDatasetId(result.getDatasetId());
 
-                // Trigger async post-processing (caching, email notifications)
-                asyncExecutor.handleAfterRecordUpdateAsync(
-                        result.getRecord(),
-                        patch.getApprovalStatus(),
-                        result.getDatasetId());
+                    // Trigger async post-processing (caching, email notifications)
+                    asyncExecutor.handleAfterRecordUpdateAsync(
+                            result.getRecord(),
+                            requestedStatus,
+                            result.getDatasetId(),
+                            RPALogContext.capture());
 
-                logUpdateAction(tokenDetails, id);
+                    logUpdateAction(tokenDetails, result.getRecord(), requestedStatus);
 
-                LOGGER.debug("Record successfully updated");
-                return new ResponseEntity<RecordStatus>(result.getRecordStatus(), HttpStatus.OK);
+                    return new ResponseEntity<RecordStatus>(result.getRecordStatus(), HttpStatus.OK);
+                } else {
+                    LOGGER.error("RPA record update denied reqId={} recordId={} reason=invalid-token",
+                            RPALogContext.requestId(), id);
+                    throw new UnauthorizedException("invalid token");
+                }
             } else {
-                LOGGER.error("Token is invalid");
-                throw new UnauthorizedException("invalid token");
+                LOGGER.error("RPA record update denied reqId={} recordId={} reason=invalid-authorization-header",
+                        RPALogContext.requestId(), id);
+                throw new UnauthorizedException("invalid authorization header");
             }
-        } else {
-            LOGGER.error("Invalid authorization header");
-            throw new UnauthorizedException("invalid authorization header");
+        } finally {
+            RPALogContext.restore(previousContext);
         }
-
     }
 
     /**
@@ -436,10 +495,19 @@ public class RPARequestHandlerController {
      *                     full name (key: "userFullname").
      * @param recordId     The ID of the record that was updated.
      */
-    private void logUpdateAction(Map<String, String> tokenDetails, String recordId) {
+    private void logUpdateAction(Map<String, String> tokenDetails, gov.nist.oar.distrib.service.rpa.model.Record record,
+            String requestedStatus) {
         String smeEmail = tokenDetails.get("userEmail");
-        String smeFullname = tokenDetails.get("userFullname");
-        LOGGER.info(smeFullname + " (" + smeEmail + ") has updated record with ID=" + recordId);
+        String recordId = record != null ? record.getId() : "unknown";
+        String datasetId = record != null && record.getUserInfo() != null ? record.getUserInfo().getSubject() : "unknown";
+        String caseNum = record != null ? record.getCaseNum() : "unknown";
+        String status = record != null && record.getUserInfo() != null
+                ? RPALogContext.summarizeApprovalStatus(record.getUserInfo().getApprovalStatus())
+                : "unknown";
+        LOGGER.info(
+                "RPA record update accepted reqId={} recordId={} caseNum={} dataset={} action={} approvalStatus={} actor={}",
+                RPALogContext.requestId(), recordId, caseNum, datasetId, requestedStatus, status,
+                RPALogContext.maskEmail(smeEmail));
     }
 
     /**

--- a/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
+++ b/src/main/java/gov/nist/oar/distrib/web/RPARequestHandlerController.java
@@ -461,6 +461,7 @@ public class RPARequestHandlerController {
                             result.getRecord(),
                             requestedStatus,
                             result.getDatasetId(),
+                            result.getPreviousApprovalStatus(),
                             RPALogContext.capture());
 
                     logUpdateAction(tokenDetails, result.getRecord(), requestedStatus);

--- a/src/test/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheckTest.java
+++ b/src/test/java/gov/nist/oar/distrib/cachemgr/CacheExpiryCheckTest.java
@@ -1,6 +1,5 @@
 package gov.nist.oar.distrib.cachemgr;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,8 +31,8 @@ public class CacheExpiryCheckTest {
 
     /**
      * Test to verify that {@link CacheExpiryCheck} correctly identifies and processes an expired cache object.
-     * An object is considered expired based on the `expires` metadata, which defines the duration after which
-     * an object should be considered expired from the time of its last modification. This test ensures that an object
+     * An object is considered expired based on the `expires` metadata, which defines the absolute epoch
+     * millisecond time when the object should expire. This test ensures that an object
      * past its expiration is appropriately removed from the inventory database.
      *
      * @throws Exception to handle any exceptions thrown during the test execution
@@ -43,8 +42,7 @@ public class CacheExpiryCheckTest {
         // Setup an expired cache object
         cacheObject.volume = mockVolume;
         when(cacheObject.hasMetadatum("expires")).thenReturn(true);
-        when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(1000L); // Expires in 1 second
-        when(cacheObject.getLastModified()).thenReturn(Instant.now().minusSeconds(10).toEpochMilli());
+        when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(Instant.now().minusSeconds(1).toEpochMilli());
         when(cacheObject.volume.remove(cacheObject.name)).thenReturn(true);
 
         expiryCheck.check(cacheObject);
@@ -55,7 +53,7 @@ public class CacheExpiryCheckTest {
 
     /**
      * Test to ensure that {@link CacheExpiryCheck} does not flag a cache object as expired if the current time has not
-     * exceeded its `expires` duration since its last modification. This test verifies that no removal action is taken
+     * exceeded its absolute `expires` time. This test verifies that no removal action is taken
      * for such non-expired objects.
      *
      * @throws Exception to handle any exceptions thrown during the test execution
@@ -66,9 +64,7 @@ public class CacheExpiryCheckTest {
         cacheObject.name = "nonExpiredObject";
         cacheObject.volname = "testVolume";
         when(cacheObject.hasMetadatum("expires")).thenReturn(true);
-        when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(14 * 24 * 60 * 60 * 1000L); // 14 days in milliseconds
-        long lastModified = System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000L); // 7 days ago, within expiry period
-        when(cacheObject.getLastModified()).thenReturn(lastModified);
+        when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(System.currentTimeMillis() + (7 * 24 * 60 * 60 * 1000L));
 
         // Perform the check
         expiryCheck.check(cacheObject);
@@ -106,7 +102,6 @@ public class CacheExpiryCheckTest {
         // Setup a non-expired cache object
         when(cacheObject.hasMetadatum("expires")).thenReturn(true);
         when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(System.currentTimeMillis() + 10000L); // Expires in the future
-        when(cacheObject.getLastModified()).thenReturn(System.currentTimeMillis());
 
         expiryCheck.check(cacheObject);
 
@@ -115,22 +110,20 @@ public class CacheExpiryCheckTest {
     }
 
     /**
-     * Tests that an {@link IntegrityException} is thrown when a cache object has the {@code expires} metadata
-     * but lacks a valid {@code lastModified} time.
+     * Tests that lastModified is not required because {@code expires} is stored as an absolute timestamp.
      *
      * @throws Exception to handle any exceptions thrown during the test execution
      */
     @Test
-    public void testObjectWithExpiresButNoLastModified_ThrowsException() throws Exception {
+    public void testObjectWithExpiresButNoLastModified_UsesAbsoluteExpires() throws Exception {
         cacheObject.name = "objectWithNoLastModified";
         cacheObject.volname = "testVolume";
         when(cacheObject.hasMetadatum("expires")).thenReturn(true);
-        when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(1000L); // Expires in 1 second
-        when(cacheObject.getLastModified()).thenReturn(-1L); // Last modified not available
+        when(cacheObject.getMetadatumLong("expires", -1L)).thenReturn(System.currentTimeMillis() + 10000L);
 
-        assertThrows(IntegrityException.class, () -> {
-            expiryCheck.check(cacheObject);
-        });
+        expiryCheck.check(cacheObject);
+
+        verify(mockInventoryDB, never()).removeObject(anyString(), anyString());
     }
 
     /**

--- a/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
@@ -715,10 +715,9 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         String recordId = "record12345";
         String email = "test@example.com";
         String country = "United States";
-        String mockRandomId = "mockRandomId123";
-        String expectedApprovalStatus = "Approved_2023-05-09T15:59:03.872Z_" + email + "_" + mockRandomId;
+        String interimResponseStatus = "ApprovalPending_2023-05-09T15:59:03.872Z_" + email;
         // Mock behavior of getRecord method
-        doReturn(getTestRecordWrapper(expectedApprovalStatus, email, country)).when(service).getRecord("record12345");
+        doReturn(getTestRecordWrapper("Pending", email, country)).when(service).getRecord("record12345");
 
         // Note: caching now happens asynchronously in handleAfterRecordUpdate, not in updateRecord
 
@@ -727,7 +726,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
         when(httpResponse.getStatusLine().getStatusCode()).thenReturn(200);
         when(httpResponse.getEntity()).thenReturn(
-                new StringEntity("{\"approvalStatus\":\"Approved_2023-05-09T15:59:03.872Z_test@example.com_mockRandomId123\"," +
+                new StringEntity("{\"approvalStatus\":\"" + interimResponseStatus + "\"," +
                         "\"recordId\":\"record12345\"}",
                         ContentType.APPLICATION_JSON)
         );
@@ -741,7 +740,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         RecordUpdateResult result = service.updateRecord(recordId, "Approved", email);
 
         // Assert
-        assertEquals(expectedApprovalStatus, result.getRecordStatus().getApprovalStatus());
+        assertEquals(interimResponseStatus, result.getRecordStatus().getApprovalStatus());
         assertEquals(recordId, result.getRecordStatus().getRecordId());
 
         // Capture the HttpPatch argument
@@ -757,6 +756,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         // Format: ApprovalPending_timestamp_email
         String expectedFormat = "ApprovalPending_\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3,9}Z_[\\w.-]+@[\\w.-]+\\.\\w+";
         assertTrue(payloadObject.get("Approval_Status__c").toString().matches(expectedFormat));
+        assertEquals(payloadObject.get("Approval_Status__c").toString(), result.getRecord().getUserInfo().getApprovalStatus());
     }
 
     /**
@@ -881,6 +881,79 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
 
         // Verify uncaching not invoked here (now happens async in handleAfterRecordUpdate)
         verify(rpaDatasetCacher, never()).uncache(anyString());
+    }
+
+    @Test
+    public void testHandleAfterRecordUpdate_approvalCompletesFinalStatusAndEmail() throws Exception {
+        String email = "sme@test.com";
+        String mockRandomId = "mockRandomId123";
+        String pendingStatus = "ApprovalPending_2023-05-09T15:59:03.872Z_" + email;
+        Record record = getTestRecordWrapper(pendingStatus, email, "United States").getRecord();
+        String datasetId = record.getUserInfo().getSubject();
+
+        when(rpaDatasetCacher.cache(datasetId)).thenReturn(mockRandomId);
+
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(200);
+
+        ArgumentCaptor<HttpPatch> captor = ArgumentCaptor.forClass(HttpPatch.class);
+        doReturn(httpResponse).when(mockHttpClient).execute(captor.capture());
+
+        service.handleAfterRecordUpdate(record, "Approved", datasetId);
+
+        HttpPatch patchRequest = captor.getValue();
+        assertEquals(getUpdateUrl(record.getId()), patchRequest.getURI().toString());
+        String patchPayload = EntityUtils.toString(patchRequest.getEntity(), StandardCharsets.UTF_8);
+        JSONObject payloadObject = new JSONObject(patchPayload);
+        assertEquals("Approved_2023-05-09T15:59:03.872Z_" + email + "_" + mockRandomId,
+                payloadObject.get("Approval_Status__c").toString());
+        assertEquals(payloadObject.get("Approval_Status__c").toString(),
+                record.getUserInfo().getApprovalStatus());
+        verify(recordResponseHandler).onRecordUpdateApproved(record, mockRandomId);
+    }
+
+    @Test
+    public void testHandleAfterRecordUpdate_approvalFailureMarksRecordFailedAndNotifiesUser() throws Exception {
+        String email = "sme@test.com";
+        String pendingStatus = "ApprovalPending_2023-05-09T15:59:03.872Z_" + email;
+        Record record = getTestRecordWrapper(pendingStatus, email, "United States").getRecord();
+        String datasetId = record.getUserInfo().getSubject();
+
+        when(rpaDatasetCacher.cache(datasetId)).thenReturn(null);
+
+        CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(200);
+
+        ArgumentCaptor<HttpPatch> captor = ArgumentCaptor.forClass(HttpPatch.class);
+        doReturn(httpResponse).when(mockHttpClient).execute(captor.capture());
+
+        service.handleAfterRecordUpdate(record, "Approved", datasetId);
+
+        String patchPayload = EntityUtils.toString(captor.getValue().getEntity(), StandardCharsets.UTF_8);
+        JSONObject payloadObject = new JSONObject(patchPayload);
+        assertEquals("ApprovalFailed_2023-05-09T15:59:03.872Z_" + email,
+                payloadObject.get("Approval_Status__c").toString());
+        assertEquals(payloadObject.get("Approval_Status__c").toString(),
+                record.getUserInfo().getApprovalStatus());
+        verify(recordResponseHandler).onFailure(record);
+        verify(rpaDatasetCacher, never()).uncache(anyString());
+    }
+
+    @Test
+    public void testHandleAfterRecordUpdate_declineUncachesAndNotifiesUser() throws Exception {
+        String email = "sme@test.com";
+        String mockRandomId = "mockRandomId123";
+        String approvedStatus = "Approved_2023-05-09T15:59:03.872Z_" + email + "_" + mockRandomId;
+        Record record = getTestRecordWrapper(approvedStatus, email, "United States").getRecord();
+
+        service.handleAfterRecordUpdate(record, "Declined", record.getUserInfo().getSubject());
+
+        verify(rpaDatasetCacher).uncache(mockRandomId);
+        verify(recordResponseHandler).onRecordUpdateDeclined(record);
     }
 
 

--- a/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
+++ b/src/test/java/gov/nist/oar/distrib/service/rpa/HttpURLConnectionRPARequestHandlerServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -328,9 +329,6 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
 
     @Test
     public void testCreateRecord_withBlacklistedEmail_DoesNotSendEmails() throws Exception {
-        // Set up mock behavior for isPreApprovedDataset
-        doReturn(false).when(service).isPreApprovedDataset(anyString());
-
         // Arrange
         RecordWrapper testRecordWrapper = getTestRecordWrapper("Some_random_status"
                 , "jane.doe@123.com", "United States");
@@ -406,9 +404,6 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
 
     @Test
     public void testCreateRecord_withBlacklistedEmail_SetsStatusAndDescriptionCorrectly() throws Exception {
-        // Set up mock behavior for isPreApprovedDataset
-        doReturn(false).when(service).isPreApprovedDataset(anyString());
-
         // Arrange
         RecordWrapper testRecordWrapper = getTestRecordWrapper("Some_random_status"
                 , "jane.doe@123.com", "United States");
@@ -460,6 +455,56 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         assertTrue(actualRecord.getRecord().getUserInfo().getDescription()
                 .contains("This record was automatically rejected."));
 
+    }
+
+    @Test
+    public void testCreateRecord_withBlacklistedPreApprovedDataset_marksRejectedBeforePosting() throws Exception {
+        lenient().doReturn(true).when(service).isPreApprovedDataset(anyString());
+
+        RecordWrapper testRecordWrapper = getTestRecordWrapper("Some_random_status",
+                "jane.doe@123.com", "United States");
+        UserInfoWrapper userInfoWrapper = new UserInfoWrapper(
+                testRecordWrapper.getRecord().getUserInfo(),
+                RECAPTCHA_RESPONSE,
+                new HashMap<>()
+        );
+
+        RPAConfiguration.BlacklistConfig blacklistConfig = new RPAConfiguration.BlacklistConfig();
+        blacklistConfig.setDisallowedEmails(List.of("@123\\."));
+        blacklistConfig.setDisallowedCountries(List.of());
+
+        Map<String, RPAConfiguration.BlacklistConfig> blacklistMap = Map.of("1234", blacklistConfig);
+        when(rpaConfiguration.getBlacklists()).thenReturn(blacklistMap);
+
+        String expectedResponseData = "{\"record\":{\"id\":\"5003R000003ErErQAK\","
+                + "\"caseNum\":\"00228987\","
+                + "\"userInfo\":{\"fullName\":\"Jane Doe\","
+                + "\"organization\":\"NASA\","
+                + "\"email\":\"jane.doe@123.com\","
+                + "\"receiveEmails\":\"Yes\","
+                + "\"country\":\"United States\","
+                + "\"approvalStatus\":\"rejected\","
+                + "\"productTitle\":\"Product title\","
+                + "\"subject\":\"1234\","
+                + "\"description\":\"This record was automatically rejected. Reason: Email is blacklisted.\""
+                + "}}}";
+        InputStream inputStream = new ByteArrayInputStream(expectedResponseData.getBytes());
+        when(mockConnection.getInputStream()).thenReturn(inputStream);
+        OutputStream osMock = mock(OutputStream.class);
+        when(mockConnection.getOutputStream()).thenReturn(osMock);
+        when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        RecordCreationResult result = service.createRecord(userInfoWrapper);
+
+        ArgumentCaptor<byte[]> payloadCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(osMock).write(payloadCaptor.capture());
+        String payload = new String(payloadCaptor.getValue(), StandardCharsets.UTF_8);
+        assertTrue(payload.contains("\"approvalStatus\":\"rejected\""));
+        assertTrue(payload.contains("This record was automatically rejected."));
+        assertTrue(!payload.contains("\"approvalStatus\":\"pre-approved\""));
+        assertEquals("rejected", userInfoWrapper.getUserInfo().getApprovalStatus());
+        assertEquals("rejected", result.getRecordWrapper().getRecord().getUserInfo().getApprovalStatus());
+        verify(service, never()).isPreApprovedDataset(anyString());
     }
 
 
@@ -878,6 +923,7 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         // Assert
         assertEquals("Declined", result.getRecordStatus().getApprovalStatus());
         assertEquals(recordId, result.getRecordStatus().getRecordId());
+        assertEquals(initialApprovalStatus, result.getPreviousApprovalStatus());
 
         // Verify uncaching not invoked here (now happens async in handleAfterRecordUpdate)
         verify(rpaDatasetCacher, never()).uncache(anyString());
@@ -951,6 +997,20 @@ public class HttpURLConnectionRPARequestHandlerServiceTest {
         Record record = getTestRecordWrapper(approvedStatus, email, "United States").getRecord();
 
         service.handleAfterRecordUpdate(record, "Declined", record.getUserInfo().getSubject());
+
+        verify(rpaDatasetCacher).uncache(mockRandomId);
+        verify(recordResponseHandler).onRecordUpdateDeclined(record);
+    }
+
+    @Test
+    public void testHandleAfterRecordUpdate_declineUsesPreviousApprovalStatusForUncache() throws Exception {
+        String email = "sme@test.com";
+        String mockRandomId = "mockRandomId123";
+        String previousApprovalStatus = "Approved_2023-05-09T15:59:03.872Z_" + email + "_" + mockRandomId;
+        String declinedStatus = "Declined_2023-05-10T15:59:03.872Z_" + email;
+        Record record = getTestRecordWrapper(declinedStatus, email, "United States").getRecord();
+
+        service.handleAfterRecordUpdate(record, "Declined", record.getUserInfo().getSubject(), previousApprovalStatus);
 
         verify(rpaDatasetCacher).uncache(mockRandomId);
         verify(recordResponseHandler).onRecordUpdateDeclined(record);

--- a/src/test/java/gov/nist/oar/distrib/web/CacheManagementControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/CacheManagementControllerTest.java
@@ -383,6 +383,8 @@ public class CacheManagementControllerTest {
         resp = websvc.exchange(getBaseURL() + "/cache/monitor/running", HttpMethod.GET, req, String.class);
         assertEquals(HttpStatus.OK, resp.getStatusCode());
 
+        waitForMonitorCycle(req, 40, 250);
+
         month = mgr.getMonitorThread();
         resp = websvc.exchange(getBaseURL() + "/cache/monitor/running?repeat=0", HttpMethod.PUT, req, String.class);
         assertEquals(HttpStatus.ACCEPTED, resp.getStatusCode());
@@ -417,6 +419,27 @@ public class CacheManagementControllerTest {
             Thread.sleep(200);
         }
         fail("Monitor failed to finish or update lastRan within timeout");
+    }
+
+    private JSONObject waitForMonitorCycle(HttpEntity<String> req, int maxAttempts, long sleepMillis)
+            throws InterruptedException {
+        ResponseEntity<String> resp = null;
+        JSONObject status = null;
+
+        int attempts = 0;
+        while (attempts++ < maxAttempts) {
+            resp = websvc.exchange(getBaseURL() + "/cache/monitor/", HttpMethod.GET, req, String.class);
+            assertEquals(HttpStatus.OK, resp.getStatusCode());
+
+            status = new JSONObject(resp.getBody());
+            if (status.getLong("lastRan") > 0) {
+                assertNotEquals("(never)", status.getString("lastRanDate"));
+                return status;
+            }
+            Thread.sleep(sleepMillis);
+        }
+        fail("Monitor failed to update lastRan within timeout");
+        return status;
     }
 
 

--- a/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
@@ -48,6 +48,7 @@ import gov.nist.oar.distrib.service.rpa.exceptions.RequestProcessingException;
 import gov.nist.oar.distrib.service.rpa.model.Record;
 import gov.nist.oar.distrib.service.rpa.model.RecordPatch;
 import gov.nist.oar.distrib.service.rpa.model.RecordStatus;
+import gov.nist.oar.distrib.service.rpa.RecordUpdateResult;
 import gov.nist.oar.distrib.service.rpa.model.RecordWrapper;
 import gov.nist.oar.distrib.service.rpa.model.UserInfo;
 import gov.nist.oar.distrib.service.rpa.model.UserInfoWrapper;
@@ -319,7 +320,8 @@ public class RPARequestHandlerControllerTest {
         String recordId = "123";
         String status = "Approved";
         RecordStatus recordStatus = new RecordStatus(recordId, status);
-        when(service.updateRecord(anyString(), anyString(), anyString())).thenReturn(recordStatus);
+        RecordUpdateResult updateResult = new RecordUpdateResult(recordStatus, null, "datasetId");
+        when(service.updateRecord(anyString(), anyString(), anyString())).thenReturn(updateResult);
 
         Map<String, String> expectedTokenDetails = new HashMap<>();
         expectedTokenDetails.put("userFullname", "john.doe");

--- a/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -293,7 +294,8 @@ public class RPARequestHandlerControllerTest {
         verify(mockAsyncExecutor).handleAfterRecordCreationAsync(
                 eq(creationResult.getRecordWrapper()),
                 argThat(actual -> areUserInfoWrappersEqual(userInfoWrapper, actual)),
-                eq(200));
+                eq(200),
+                anyMap());
     
     }
 
@@ -345,7 +347,7 @@ public class RPARequestHandlerControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recordId").value("123"));
 
-        verify(mockAsyncExecutor).handleAfterRecordUpdateAsync(record, status, "datasetId");
+        verify(mockAsyncExecutor).handleAfterRecordUpdateAsync(eq(record), eq(status), eq("datasetId"), anyMap());
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
@@ -321,11 +321,13 @@ public class RPARequestHandlerControllerTest {
     void testUpdateRecord() throws Exception {
         String recordId = "123";
         String status = "Approved";
+        String previousApprovalStatus = "Pending";
         RecordStatus recordStatus = new RecordStatus(recordId, status);
         UserInfo userInfo = new UserInfo();
         userInfo.setSubject("datasetId");
         Record record = new Record(recordId, "case-123", userInfo);
-        RecordUpdateResult updateResult = new RecordUpdateResult(recordStatus, record, "datasetId");
+        RecordUpdateResult updateResult = new RecordUpdateResult(recordStatus, record, "datasetId",
+                previousApprovalStatus);
         when(service.updateRecord(anyString(), anyString(), anyString())).thenReturn(updateResult);
 
         Map<String, String> expectedTokenDetails = new HashMap<>();
@@ -347,7 +349,8 @@ public class RPARequestHandlerControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recordId").value("123"));
 
-        verify(mockAsyncExecutor).handleAfterRecordUpdateAsync(eq(record), eq(status), eq("datasetId"), anyMap());
+        verify(mockAsyncExecutor).handleAfterRecordUpdateAsync(eq(record), eq(status), eq("datasetId"),
+                eq(previousApprovalStatus), anyMap());
     }
 
     @Test

--- a/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
+++ b/src/test/java/gov/nist/oar/distrib/web/RPARequestHandlerControllerTest.java
@@ -320,7 +320,10 @@ public class RPARequestHandlerControllerTest {
         String recordId = "123";
         String status = "Approved";
         RecordStatus recordStatus = new RecordStatus(recordId, status);
-        RecordUpdateResult updateResult = new RecordUpdateResult(recordStatus, null, "datasetId");
+        UserInfo userInfo = new UserInfo();
+        userInfo.setSubject("datasetId");
+        Record record = new Record(recordId, "case-123", userInfo);
+        RecordUpdateResult updateResult = new RecordUpdateResult(recordStatus, record, "datasetId");
         when(service.updateRecord(anyString(), anyString(), anyString())).thenReturn(updateResult);
 
         Map<String, String> expectedTokenDetails = new HashMap<>();
@@ -341,6 +344,8 @@ public class RPARequestHandlerControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, headers.getFirst(HttpHeaders.AUTHORIZATION)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recordId").value("123"));
+
+        verify(mockAsyncExecutor).handleAfterRecordUpdateAsync(record, status, "datasetId");
     }
 
     @Test


### PR DESCRIPTION
This PR introduces asynchronous post-processing for RPA record updates so the SME approval UI does not wait on long-running backend work such as restricted dataset caching and email delivery.

## Problem

When an SME approves an RPA request, the backend previously performed the full approval workflow during the HTTP request:

1. Validate the SME JWT token.
2. Fetch the existing record from Salesforce.
3. Cache the restricted dataset.
4. PATCH the record status in Salesforce.
5. Send user notification emails.

Dataset caching can be slow for large files, and email delivery adds more latency. Keeping those operations in the request path can cause the Angular client to time out even when the approval eventually succeeds.

## Solution

The update flow is split into a fast synchronous step and a background post-processing step.

### Synchronous Request Path

The controller now does only the work needed to validate the request and persist an accepted approval transition:

1. Validate the SME JWT token.
2. Fetch the current Salesforce record.
3. PATCH Salesforce with an interim approval status:

```text
ApprovalPending_<timestamp>_<smeEmail>
```

4. Return the Salesforce `RecordStatus` response to the client.
5. Dispatch async post-processing with the record, requested status, dataset ID, and logging context.

This lets the UI receive a response quickly instead of waiting for caching and email work to finish.

### Asynchronous Post-Processing

For approvals, the async worker completes the expensive backend work:

1. Cache the restricted dataset.
2. Generate the temporary RPA download identifier.
3. PATCH Salesforce with the final approval status:

```text
Approved_<timestamp>_<smeEmail>_<randomId>
```

4. Send the success email containing the download link.

If approval post-processing fails, the worker patches Salesforce to:

```text
ApprovalFailed_<timestamp>_<smeEmail>
```

and sends the failure notification email. This prevents records from remaining indefinitely in `ApprovalPending` when the background work cannot complete.

For declines, the synchronous request still patches Salesforce to:

```text
Declined_<timestamp>_<smeEmail>
```

and notification work is dispatched outside the request path.

## Implementation Notes

- Added async update post-processing through `RPAAsyncExecutor`.
- Updated the RPA request handler contract so update post-processing can run after the HTTP response path has completed.
- Updated the controller to return immediately after the Salesforce status PATCH and then dispatch background work.
- Added finalization logic that converts `ApprovalPending` into either `Approved` with a generated download ID or `ApprovalFailed` if caching/finalization fails.
- Added logging context propagation so the initial request and async worker logs can be traced.
- Added backend test coverage for synchronous approval response behavior and async approval finalization/failure behavior.

## Expected Backend Status Flow

Approval request accepted:

```text
Pending -> ApprovalPending_<timestamp>_<smeEmail>
```

Approval post-processing succeeds:

```text
ApprovalPending_<timestamp>_<smeEmail> -> Approved_<timestamp>_<smeEmail>_<randomId>
```

Approval post-processing fails:

```text
ApprovalPending_<timestamp>_<smeEmail> -> ApprovalFailed_<timestamp>_<smeEmail>
```

Decline request accepted:

```text
Pending|Approved|ApprovalFailed -> Declined_<timestamp>_<smeEmail>
```

## Verification

Backend tests:

```bash
mvn -Dtest=HttpURLConnectionRPARequestHandlerServiceTest,RPARequestHandlerControllerTest test
```

Tested locally under oar-docker.

## Note: Logging Cleanup

This PR also reworks RPA workflow logging to consider events for the synchronous request and async worker. Logs now carry shared request/workflow context into background processing, and avoid dumps of sensitive payloads, JWT material, Salesforce tokens, and full email bodies.
